### PR TITLE
Add Docker and virtualenv setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python
+__pycache__/
+*.py[cod]
+venv/
+
+# Data
+data/*.duckdb
+
+# DBT
+mini_dwh_dbt/target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use official Python runtime
+FROM python:3.11-slim
+
+# Set workdir
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project
+COPY . .
+
+# Default command
+CMD ["python", "orchestrator.py"]

--- a/README.md
+++ b/README.md
@@ -16,18 +16,28 @@ data pipeline on a daily schedule.
 
 ## Requirements
 
-Install dependencies with pip:
+It is recommended to use a Python virtual environment. Create one and
+install the required packages from `requirements.txt`:
 
 ```bash
-pip install duckdb dbt-core schedule
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
 ```
 
 ## Running the pipeline
 
-1. Initialize the database by running the orchestrator:
+1. Initialize the database by running the orchestrator locally:
 
 ```bash
 python orchestrator.py
+```
+
+Alternatively build and start the Docker container. The `data/` folder is
+mounted so the DuckDB file is accessible on the host:
+
+```bash
+docker compose up --build
 ```
 
 The script runs `dbt seed`, `dbt run` and `dbt test` once and then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  dwh:
+    build: .
+    volumes:
+      - ./data:/app/data
+    command: python orchestrator.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+duckdb
+schedule
+dbt-core
+dbt-duckdb


### PR DESCRIPTION
## Summary
- ignore build output and database file
- document using a Python virtualenv
- provide Dockerfile and docker-compose setup
- list Python requirements
- keep a placeholder in `data/` so the DB path can be mounted

## Testing
- `python -m py_compile orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_685c8672f9f88327b29f25a2763bc64e