### PR TITLE
Add hourly commodity price ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 This repository contains a minimal example of a data warehouse using
 [DuckDB](https://duckdb.org/) with transformation models managed by
 [dbt](https://www.getdbt.com/). An example orchestration script runs the
-data pipeline on a daily schedule.
+data pipeline on an hourly schedule and fetches commodity prices before
+each dbt run.
 
 ## Project structure
 
 - `mini_dwh_dbt/` - dbt project containing models for bronze, silver and
   gold layers.
 - `mini_dwh_dbt/seeds/raw/` - example CSV datasets loaded as seeds.
-- `orchestrator.py` - simple scheduler that executes the dbt pipeline
-  every day.
+- `orchestrator.py` - scheduler that fetches commodity prices and runs
+  the dbt pipeline every hour.
 - `data/warehouse.duckdb` - DuckDB file created when the pipeline runs.
 
 ## Requirements
@@ -41,7 +42,8 @@ docker compose up --build
 ```
 
 The script runs `dbt seed`, `dbt run` and `dbt test` once and then
-schedules the same sequence to run daily at midnight.
+schedules the same sequence to run every hour. Before each run it
+downloads the latest commodity prices.
 
 ## dbt configuration
 

--- a/fetch_commodity_prices.py
+++ b/fetch_commodity_prices.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import yfinance as yf
+
+
+DATA_PATH = Path(__file__).parent / "mini_dwh_dbt" / "seeds" / "external" / "commodity_prices.csv"
+
+
+def fetch_commodity_prices() -> None:
+    """Download commodity prices for the last five years and store as a CSV."""
+    tickers = {
+        "wheat": "ZW=F",
+        "corn": "ZC=F",
+        "soybeans": "ZS=F",
+    }
+    end = datetime.utcnow()
+    start = end - timedelta(days=5 * 365)
+    frames = []
+    for name, ticker in tickers.items():
+        df = yf.download(ticker, start=start, end=end, interval="1h")
+        if df.empty:
+            continue
+        df = df.reset_index()[["Datetime", "Close"]]
+        df["commodity"] = name
+        frames.append(df)
+    if not frames:
+        return
+    result = pd.concat(frames)
+    result.rename(columns={"Datetime": "timestamp", "Close": "price"}, inplace=True)
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(DATA_PATH, index=False)
+
+
+if __name__ == "__main__":
+    fetch_commodity_prices()

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -2,6 +2,8 @@ import subprocess
 import schedule
 import time
 
+from fetch_commodity_prices import fetch_commodity_prices
+
 
 def run_dbt_pipeline():
     """Run dbt commands for the full pipeline."""
@@ -10,10 +12,16 @@ def run_dbt_pipeline():
     subprocess.run(["dbt", "test"], check=True)
 
 
-def main():
-    schedule.every().day.at("00:00").do(run_dbt_pipeline)
-    print("Starting orchestration loop. Press Ctrl+C to stop.")
+def run_full_pipeline():
+    """Fetch commodity data and run the dbt pipeline."""
+    fetch_commodity_prices()
     run_dbt_pipeline()
+
+
+def main():
+    schedule.every().hour.do(run_full_pipeline)
+    print("Starting orchestration loop. Press Ctrl+C to stop.")
+    run_full_pipeline()
     while True:
         schedule.run_pending()
         time.sleep(60)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ duckdb
 schedule
 dbt-core
 dbt-duckdb
+pandas
+yfinance


### PR DESCRIPTION
## Summary
- build commodity price fetcher using yfinance
- run fetcher before dbt pipeline in orchestrator
- schedule orchestrator hourly
- document new pipeline behaviour
- include required python dependencies

## Testing
- `python -m py_compile fetch_commodity_prices.py orchestrator.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c88948ee88327a9b778415b7b3c94