### PR TITLE
Add Prefect flow for pipeline monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ The script runs `dbt seed`, `dbt run` and `dbt test` once and then
 schedules the same sequence to run every hour. Before each run it
 downloads the latest commodity prices.
 
+## Pipeline monitoring with Prefect
+
+The project includes an optional Prefect flow in `prefect_flow.py` so you
+can monitor pipeline runs using Prefect's UI.
+
+Start the local Prefect server in one terminal:
+
+```bash
+poetry run prefect orion start
+```
+
+Then execute the flow in another terminal:
+
+```bash
+poetry run python prefect_flow.py
+```
+
+The Prefect UI, available at `http://127.0.0.1:4200`, shows the status of
+each run so you can keep track of your pipeline executions.
+
 ## dbt configuration
 
 The dbt profile in `mini_dwh_dbt/profiles.yml` points to

--- a/prefect_flow.py
+++ b/prefect_flow.py
@@ -1,0 +1,29 @@
+from prefect import task, flow
+import subprocess
+
+from fetch_commodity_prices import fetch_commodity_prices
+
+
+@task
+def fetch_data():
+    """Download commodity prices and store them as a CSV."""
+    fetch_commodity_prices()
+
+
+@task
+def run_dbt_pipeline():
+    """Execute the dbt commands for the full pipeline."""
+    subprocess.run(["dbt", "seed"], check=True)
+    subprocess.run(["dbt", "run"], check=True)
+    subprocess.run(["dbt", "test"], check=True)
+
+
+@flow
+def full_pipeline() -> None:
+    """Prefect flow that fetches data and runs dbt."""
+    fetch_data()
+    run_dbt_pipeline()
+
+
+if __name__ == "__main__":
+    full_pipeline()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ duckdb = "*"
 schedule = "*"
 dbt-core = "*"
 dbt-duckdb = "*"
+prefect = "*"
 
 [tool.poetry.group.dev.dependencies]
 # Add dev dependencies here

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ dbt-core
 dbt-duckdb
 pandas
 yfinance
+prefect


### PR DESCRIPTION
## Summary
- add Prefect dependency to project
- create `prefect_flow.py` with a Prefect-based pipeline
- document how to start Prefect UI and run the flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8a39c61c8327b081ac1e6946e055