### PR TITLE
Fix poetry install error by disabling package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "mini-dwh"
 version = "0.1.0"
 description = "Mini data warehouse example using DuckDB and dbt"
 authors = ["Your Name <you@example.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
## Summary
- disable package mode so Poetry doesn't expect a package

## Testing
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c8afb706c832798e69866cbac0f81