### PR TITLE
Fix missing pandas dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ each dbt run.
 
 Dependencies are managed with [Poetry](https://python-poetry.org/). Create a
 virtual environment (Poetry will do this automatically) and install the
-dependencies:
+dependencies (including `pandas` and `yfinance` used to fetch commodity
+prices):
 
 ```bash
 pip install poetry  # if Poetry is not installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ schedule = "*"
 dbt-core = "*"
 dbt-duckdb = "*"
 prefect = "*"
+pandas = "*"
+yfinance = "*"
 
 [tool.poetry.group.dev.dependencies]
 # Add dev dependencies here


### PR DESCRIPTION
## Summary
- install pandas and yfinance via Poetry
- mention pandas and yfinance in the setup docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8c56d34c832793a23b0199c2c23a