### PR TITLE
Fix dbt profile path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ docker compose up --build
 ```
 
 The service mounts the `data/` directory so the DuckDB file is available on
-the host. Once the container is running you can open a shell inside it if
+the host. The orchestrator sets `DBT_PROFILES_DIR` automatically so dbt uses
+the bundled profile. Once the container is running you can open a shell inside it if
 you want to execute additional `dbt` commands or inspect the database:
 
 ```bash
@@ -87,8 +88,9 @@ each run so you can keep track of your pipeline executions.
 ## dbt configuration
 
 The dbt profile in `mini_dwh_dbt/profiles.yml` points to
-`data/warehouse.duckdb`. You can override the path by setting the
-`DUCKDB_PATH` environment variable.
+`data/warehouse.duckdb`. The orchestrator automatically sets
+`DBT_PROFILES_DIR` to use this profile. You can override the database path by
+setting the `DUCKDB_PATH` environment variable.
 
 ```yaml
 mini_dwh:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import schedule
 import time
@@ -8,6 +9,9 @@ from fetch_commodity_prices import fetch_commodity_prices
 from pathlib import Path
 
 DBT_DIR = Path(__file__).parent / "mini_dwh_dbt"
+
+# Ensure dbt uses the project-specific profile rather than the default
+os.environ.setdefault("DBT_PROFILES_DIR", str(DBT_DIR))
 
 
 def run_dbt_pipeline():

--- a/prefect_flow.py
+++ b/prefect_flow.py
@@ -1,10 +1,14 @@
 from prefect import task, flow
+import os
 import subprocess
 
 from fetch_commodity_prices import fetch_commodity_prices
 from pathlib import Path
 
 DBT_DIR = Path(__file__).parent / "mini_dwh_dbt"
+
+# Ensure dbt uses the project-specific profile
+os.environ.setdefault("DBT_PROFILES_DIR", str(DBT_DIR))
 
 
 @task


### PR DESCRIPTION
## Summary
- ensure DBT_PROFILES_DIR is set for dbt commands
- mention bundled dbt profile in README

## Testing
- `pytest -q`
- `docker compose up --build --abort-on-container-exit` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c91e2f848832792d3852948ad5bf8