### PR TITLE
Move commodity fetcher into sources package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ each dbt run.
 
 - `mini_dwh_dbt/` - dbt project containing models for bronze, silver and
   gold layers.
+- `sources/` - Python modules that download external datasets. Each module
+  implements a `fetch()` function.
 - `mini_dwh_dbt/seeds/raw/` - example CSV datasets loaded as seeds.
 - `orchestrator.py` - scheduler that fetches commodity prices and runs
   the dbt pipeline every hour.
@@ -96,6 +98,14 @@ poetry run python prefect_flow.py
 
 The Prefect UI, available at `http://127.0.0.1:4200`, shows the status of
 each run so you can keep track of your pipeline executions.
+
+## Adding new data sources
+
+Fetcher modules live in the `sources/` package. Each module must implement a
+`fetch()` function that downloads the raw data. See `sources/README.md` for
+instructions. Update `pipeline_config.yml` with the fully qualified module
+path (for example `sources.my_source.fetch`) so the orchestrator can locate
+the function.
 
 ## dbt configuration
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -3,7 +3,7 @@ import subprocess
 import schedule
 import time
 
-from fetch_commodity_prices import fetch_commodity_prices
+from sources.commodities import fetch as fetch_commodities
 
 
 from pathlib import Path
@@ -23,7 +23,7 @@ def run_dbt_pipeline():
 
 def run_full_pipeline():
     """Fetch commodity data and run the dbt pipeline."""
-    fetch_commodity_prices()
+    fetch_commodities()
     run_dbt_pipeline()
 
 

--- a/pipeline_config.yml
+++ b/pipeline_config.yml
@@ -1,6 +1,6 @@
 sources:
   - name: commodities
-    fetcher: fetch_commodity_prices.fetch_commodity_prices
+    fetcher: sources.commodities.fetch
     schedule: "hourly"
     models:
       - orders_enriched

--- a/prefect_flow.py
+++ b/prefect_flow.py
@@ -2,7 +2,7 @@ from prefect import task, flow
 import os
 import subprocess
 
-from fetch_commodity_prices import fetch_commodity_prices
+from sources.commodities import fetch as fetch_commodities
 from pathlib import Path
 
 DBT_DIR = Path(__file__).parent / "mini_dwh_dbt"
@@ -14,7 +14,7 @@ os.environ.setdefault("DBT_PROFILES_DIR", str(DBT_DIR))
 @task
 def fetch_data():
     """Download commodity prices and store them as a CSV."""
-    fetch_commodity_prices()
+    fetch_commodities()
 
 
 @task

--- a/sources/README.md
+++ b/sources/README.md
@@ -1,0 +1,15 @@
+# Source Modules
+
+This package contains modules responsible for fetching raw datasets used by the data warehouse. Each module exposes a single `fetch()` function which downloads data and writes it to the appropriate location under `mini_dwh_dbt/seeds/`.
+
+To add a new source:
+
+1. Create a new Python module inside `sources/`.
+2. Implement a `fetch()` function that performs the data download and persists the results.
+3. Reference the function in `pipeline_config.yml` (for example `sources.my_source.fetch`).
+
+Modules can also be executed directly for ad-hoc runs using:
+
+```bash
+python -m sources.my_source
+```

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -1,0 +1,1 @@
+"""Data source fetcher modules."""

--- a/sources/commodities.py
+++ b/sources/commodities.py
@@ -6,7 +6,7 @@ import yfinance as yf
 
 
 DATA_PATH = (
-    Path(__file__).parent
+    Path(__file__).resolve().parent.parent
     / "mini_dwh_dbt"
     / "seeds"
     / "external"
@@ -14,8 +14,8 @@ DATA_PATH = (
 )
 
 
-def fetch_commodity_prices() -> None:
-    """Download commodity prices for the last five years and store as a CSV."""
+def fetch() -> None:
+    """Download commodity prices for the last five years and store them as a CSV."""
     tickers = {
         "wheat": "ZW=F",
         "corn": "ZC=F",
@@ -40,4 +40,4 @@ def fetch_commodity_prices() -> None:
 
 
 if __name__ == "__main__":
-    fetch_commodity_prices()
+    fetch()


### PR DESCRIPTION
## Summary
- introduce `sources` package for data fetchers
- move `fetch_commodity_prices.py` to `sources/commodities.py` and expose `fetch()`
- update orchestrator and Prefect flow to use new path
- update pipeline configuration
- document new package usage

## Testing
- `python -m compileall -q sources orchestrator.py prefect_flow.py pipeline_config.yml README.md`

------
https://chatgpt.com/codex/tasks/task_e_685c962cd384832798fd1352e24d62c6