### PR TITLE
Add dynamic per-source scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 This repository contains a minimal example of a data warehouse using
 [DuckDB](https://duckdb.org/) with transformation models managed by
-[dbt](https://www.getdbt.com/). An example orchestration script runs the
-data pipeline on an hourly schedule and fetches commodity prices before
-each dbt run.
+[dbt](https://www.getdbt.com/). An orchestration script reads
+`pipeline_config.yml` at startup and schedules each data source
+individually. Before running the selected dbt models the configured fetch
+function is executed for that source.
 
 ## Project structure
 
 - `mini_dwh_dbt/` - dbt project containing models for bronze, silver and
   gold layers.
 - `mini_dwh_dbt/seeds/raw/` - example CSV datasets loaded as seeds.
-- `orchestrator.py` - scheduler that fetches commodity prices and runs
-  the dbt pipeline every hour.
+- `orchestrator.py` - scheduler that loads `pipeline_config.yml` and
+  executes each source on its defined schedule.
 - `mini_dwh_dbt/` is used as the working directory for all dbt commands
   executed by the orchestrator and Prefect flow.
 - `data/warehouse.duckdb` - DuckDB file created when the pipeline runs.
@@ -50,8 +51,8 @@ dbt run -s models/bronze/orders_bronze.sql
 ## Running the pipeline
 
 The simplest way to get started is to build and start the Docker
-container. This spins up the orchestrator and schedules the pipeline
-immediately:
+container. This spins up the orchestrator which loads
+`pipeline_config.yml` and schedules the configured sources immediately:
 
 ```bash
 docker compose up --build
@@ -66,9 +67,8 @@ you want to execute additional `dbt` commands or inspect the database:
 docker compose exec dwh bash
 ```
 
-Running the container executes `dbt seed`, `dbt run` and `dbt test` once and
-then schedules the same sequence every hour. Before each run the latest
-commodity prices are downloaded.
+Running the container executes each source once and then continues to run
+them based on the schedule defined in `pipeline_config.yml`.
 
 If you prefer running everything locally, execute the orchestrator with
 Poetry instead:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -2,35 +2,85 @@ import os
 import subprocess
 import schedule
 import time
-
-from fetch_commodity_prices import fetch_commodity_prices
-
-
+import yaml
+import importlib
+import logging
 from pathlib import Path
 
 DBT_DIR = Path(__file__).parent / "mini_dwh_dbt"
+CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
 
 # Ensure dbt uses the project-specific profile rather than the default
 os.environ.setdefault("DBT_PROFILES_DIR", str(DBT_DIR))
 
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
-def run_dbt_pipeline():
-    """Run dbt commands for the full pipeline."""
+
+def run_dbt_pipeline(models: list[str]) -> None:
+    """Run dbt commands for the selected models."""
+    logging.info("Running dbt models: %s", ", ".join(models))
     subprocess.run(["dbt", "seed"], check=True, cwd=DBT_DIR)
-    subprocess.run(["dbt", "run"], check=True, cwd=DBT_DIR)
-    subprocess.run(["dbt", "test"], check=True, cwd=DBT_DIR)
+    if models:
+        subprocess.run(["dbt", "run", "-s", *models], check=True, cwd=DBT_DIR)
+        subprocess.run(["dbt", "test", "-s", *models], check=True, cwd=DBT_DIR)
+    else:
+        subprocess.run(["dbt", "run"], check=True, cwd=DBT_DIR)
+        subprocess.run(["dbt", "test"], check=True, cwd=DBT_DIR)
 
 
-def run_full_pipeline():
-    """Fetch commodity data and run the dbt pipeline."""
-    fetch_commodity_prices()
-    run_dbt_pipeline()
+def load_config() -> list[dict]:
+    """Load pipeline configuration from ``pipeline_config.yml``."""
+    with open(CONFIG_FILE) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("sources", [])
 
 
-def main():
-    schedule.every().hour.do(run_full_pipeline)
-    print("Starting orchestration loop. Press Ctrl+C to stop.")
-    run_full_pipeline()
+def schedule_source(source: dict) -> None:
+    """Schedule fetching and dbt execution for a single source."""
+    name = source.get("name", "unknown")
+    fetcher_path = source["fetcher"]
+    models = source.get("models", [])
+    sched = source.get("schedule", "hourly")
+
+    module_path, func_name = fetcher_path.rsplit(".", 1)
+    fetch_module = importlib.import_module(module_path)
+    fetch_func = getattr(fetch_module, func_name)
+
+    def run_source() -> None:
+        logging.info("Running source '%s'", name)
+        fetch_func()
+        run_dbt_pipeline(models)
+
+    job = schedule.every()
+    s = str(sched).lower()
+    if s == "hourly":
+        job = job.hour
+    elif s == "daily":
+        job = job.day
+    elif s == "weekly":
+        job = job.week
+    elif s.startswith("every"):
+        parts = s.split()
+        if len(parts) >= 3:
+            interval = int(parts[1])
+            unit = parts[2].rstrip("s")
+            job = getattr(schedule.every(interval), unit)
+        else:
+            raise ValueError(f"Invalid schedule format: {sched}")
+    else:
+        # Assume HH:MM format for daily execution
+        job = job.day.at(sched)
+
+    job.do(run_source)
+    # Run once at startup
+    run_source()
+
+
+def main() -> None:
+    for source in load_config():
+        schedule_source(source)
+
+    logging.info("Starting orchestration loop. Press Ctrl+C to stop.")
     while True:
         schedule.run_pending()
         time.sleep(60)


### PR DESCRIPTION
## Summary
- load pipeline configuration on startup
- dynamically import source fetchers and schedule each source individually
- log which source and dbt models are running
- document new config-driven orchestration

## Testing
- `python -m py_compile orchestrator.py`
- `python -m py_compile fetch_commodity_prices.py prefect_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_685c9637e6f08327838553ec0f7b3312