### PR TITLE
Add Prefect deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ poetry run python orchestrator.py
 ## Pipeline monitoring with Prefect
 
 The project includes an optional Prefect flow in `prefect_flow.py` so you
-can monitor pipeline runs using Prefect's UI.
+can monitor pipeline runs using Prefect's UI. Deployments are created from
+`pipeline_config.yml` using `register_deployments.py`.
 
 Start the local Prefect server in one terminal:
 
@@ -90,10 +91,16 @@ Start the local Prefect server in one terminal:
 poetry run prefect orion start
 ```
 
-Then execute the flow in another terminal:
+Register the deployments in another terminal:
 
 ```bash
-poetry run python prefect_flow.py
+poetry run python register_deployments.py
+```
+
+Finally, start a worker to execute scheduled runs:
+
+```bash
+poetry run prefect agent start -q default
 ```
 
 The Prefect UI, available at `http://127.0.0.1:4200`, shows the status of

--- a/register_deployments.py
+++ b/register_deployments.py
@@ -1,0 +1,59 @@
+# Register Prefect deployments based on pipeline_config.yml
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+import yaml
+from prefect.deployments import Deployment
+from prefect.server.schemas.schedules import CronSchedule, IntervalSchedule
+
+from prefect_flow import pipeline
+
+CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
+
+
+def load_config() -> list[dict]:
+    with open(CONFIG_FILE) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("sources", [])
+
+
+def parse_schedule(expr: str):
+    s = str(expr).lower()
+    if s == "hourly":
+        return IntervalSchedule(interval=timedelta(hours=1))
+    if s == "daily":
+        return IntervalSchedule(interval=timedelta(days=1))
+    if s == "weekly":
+        return IntervalSchedule(interval=timedelta(weeks=1))
+    if s.startswith("every"):
+        parts = s.split()
+        if len(parts) >= 3:
+            interval = int(parts[1])
+            unit = parts[2].rstrip("s")
+            return IntervalSchedule(interval=timedelta(**{unit + "s": interval}))
+        raise ValueError(f"Invalid schedule format: {expr}")
+    # Assume HH:MM format for daily execution
+    hour, minute = map(int, s.split(":"))
+    return CronSchedule(cron=f"{minute} {hour} * * *")
+
+
+def register_deployments() -> None:
+    for source in load_config():
+        name = source.get("name", "source")
+        fetcher = source["fetcher"]
+        models = source.get("models", [])
+        schedule = parse_schedule(source.get("schedule", "hourly"))
+        deployment = Deployment.build_from_flow(
+            flow=pipeline,
+            name=name,
+            parameters={"fetcher": fetcher, "models": models},
+            schedule=schedule,
+        )
+        deployment.apply()
+        print(f"Registered deployment for {name}")
+
+
+if __name__ == "__main__":
+    register_deployments()


### PR DESCRIPTION
## Summary
- refactor `prefect_flow.py` to accept fetch function and model list
- add `register_deployments.py` to build deployments from `pipeline_config.yml`
- update Prefect documentation on how to start the server, register deployments and run workers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c97aad7e88327958ce43c7c666cef