### PR TITLE
Fix orchestrator DB path and limit commodity fetch range

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -20,12 +20,23 @@ CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
 # Ensure dbt uses the project-specific profile rather than the default
 os.environ.setdefault("DBT_PROFILES_DIR", str(DBT_DIR))
 
+# Ensure the DuckDB directory exists before running dbt
+def _ensure_duckdb_dir() -> None:
+    """Create the parent directory for the DuckDB file if needed."""
+    path = os.environ.get("DUCKDB_PATH")
+    if path:
+        dir_path = Path(path).expanduser().parent
+    else:
+        dir_path = DBT_DIR / "data"
+    dir_path.mkdir(parents=True, exist_ok=True)
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
 
 def run_dbt_pipeline(models: list[str]) -> None:
     """Run dbt commands for the selected models."""
     logging.info("Running dbt models: %s", ", ".join(models))
+    _ensure_duckdb_dir()
     subprocess.run(["dbt", "seed"], check=True, cwd=DBT_DIR)
     if models:
         subprocess.run(["dbt", "run", "-s", *models], check=True, cwd=DBT_DIR)

--- a/sources/commodities.py
+++ b/sources/commodities.py
@@ -15,14 +15,14 @@ DATA_PATH = (
 
 
 def fetch() -> None:
-    """Download commodity prices for the last five years and store them as a CSV."""
+    """Download commodity prices for roughly the last two years."""
     tickers = {
         "wheat": "ZW=F",
         "corn": "ZC=F",
         "soybeans": "ZS=F",
     }
     end = datetime.utcnow()
-    start = end - timedelta(days=5 * 365)
+    start = end - timedelta(days=720)
     frames = []
     for name, ticker in tickers.items():
         df = yf.download(ticker, start=start, end=end, interval="1h")


### PR DESCRIPTION
## Summary
- create helper in `orchestrator.py` to ensure the DuckDB directory exists before running dbt
- call the helper from `run_dbt_pipeline`
- fetch only ~2 years of historical commodity prices to avoid yfinance errors

## Testing
- `python -m py_compile orchestrator.py sources/commodities.py`


------
https://chatgpt.com/codex/tasks/task_e_685c9a70cf9c83278dcd64fe3e9563e6