### PR TITLE
Improve orchestrator error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ docker compose exec dwh bash
 
 Running the container executes each source once and then continues to run
 them based on the schedule defined in `pipeline_config.yml`.
+Errors during fetching or model execution are logged. The orchestrator
+continues scheduling other runs so the container stays alive even if a
+step fails.
 
 If you prefer running everything locally, execute the orchestrator with
 Poetry instead:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -71,8 +71,15 @@ def schedule_source(source: dict, active: set[str]) -> None:
 
     def run_source() -> None:
         logging.info("Running source '%s'", name)
-        fetch_func()
-        run_dbt_pipeline(source_models)
+        try:
+            fetch_func()
+        except Exception:
+            logging.exception("Error fetching source '%s'", name)
+            return
+        try:
+            run_dbt_pipeline(source_models)
+        except Exception:
+            logging.exception("Error running dbt for source '%s'", name)
 
     job = schedule.every()
     s = str(sched).lower()


### PR DESCRIPTION
## Summary
- prevent unexpected termination of the orchestrator by logging errors during fetch and dbt steps
- document that the orchestrator keeps running even if a step fails

## Testing
- `python -m compileall -q orchestrator.py sources/commodities.py`

------
https://chatgpt.com/codex/tasks/task_e_685c9ea728808327bbbc00cbeaaefe92