### PR TITLE
Switch from DuckDB to Postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,5 @@ __pycache__/
 *.py[cod]
 venv/
 
-# Data
-data/*.duckdb
-
 # DBT
 mini_dwh_dbt/target/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,25 @@ services:
     volumes:
       - ./data:/app/data
     command: python orchestrator.py
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: mini_dwh
+      POSTGRES_PORT: 5432
+    depends_on:
+      - postgres
 
-  webui:
-    image: ghcr.io/duckdb/duckdb-wasm-shell:latest
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: mini_dwh
     ports:
-      - "8080:8080"
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/mini_dwh_dbt/profiles.yml
+++ b/mini_dwh_dbt/profiles.yml
@@ -2,5 +2,11 @@ mini_dwh:
   target: dev
   outputs:
     dev:
-      type: duckdb
-      path: "data/warehouse.duckdb"
+      type: postgres
+      threads: 1
+      host: "{{ env_var('POSTGRES_HOST', 'localhost') }}"
+      port: "{{ env_var('POSTGRES_PORT', '5432') }}"
+      user: "{{ env_var('POSTGRES_USER', 'postgres') }}"
+      pass: "{{ env_var('POSTGRES_PASSWORD', 'postgres') }}"
+      dbname: "{{ env_var('POSTGRES_DB', 'mini_dwh') }}"
+      schema: public

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -20,15 +20,6 @@ CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
 # Ensure dbt uses the project-specific profile rather than the default
 os.environ.setdefault("DBT_PROFILES_DIR", str(DBT_DIR))
 
-# Ensure the DuckDB directory exists before running dbt
-def _ensure_duckdb_dir() -> None:
-    """Create the parent directory for the DuckDB file if needed."""
-    path = os.environ.get("DUCKDB_PATH")
-    if path:
-        dir_path = Path(path).expanduser().parent
-    else:
-        dir_path = DBT_DIR / "data"
-    dir_path.mkdir(parents=True, exist_ok=True)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
@@ -36,7 +27,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 def run_dbt_pipeline(models: list[str]) -> None:
     """Run dbt commands for the selected models."""
     logging.info("Running dbt models: %s", ", ".join(models))
-    _ensure_duckdb_dir()
     subprocess.run(["dbt", "seed"], check=True, cwd=DBT_DIR)
     if models:
         subprocess.run(["dbt", "run", "-s", *models], check=True, cwd=DBT_DIR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,19 @@
 [tool.poetry]
 name = "mini-dwh"
 version = "0.1.0"
-description = "Mini data warehouse example using DuckDB and dbt"
+description = "Mini data warehouse example using PostgreSQL and dbt"
 authors = ["Your Name <you@example.com>"]
 package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
-duckdb = "*"
 schedule = "*"
 dbt-core = "*"
-dbt-duckdb = "*"
+dbt-postgres = "*"
 prefect = "*"
 pandas = "*"
 yfinance = "*"
+psycopg2-binary = "*"
 
 [tool.poetry.group.dev.dependencies]
 # Add dev dependencies here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements exported from Poetry
-duckdb
 schedule
 dbt-core
-dbt-duckdb
+dbt-postgres
 pandas
 yfinance
 prefect
+psycopg2-binary


### PR DESCRIPTION
## Summary
- update dependencies for Postgres
- run Postgres in docker-compose and wire environment variables
- update dbt profile for Postgres
- simplify orchestrator (remove DuckDB dir handling)
- update docs for the Postgres-based setup
- clean up .gitignore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca24ca66483279cf5567c88eb7dc6