### PR TITLE
Revert back to DuckDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ __pycache__/
 *.py[cod]
 venv/
 
+# Data
+data/*.duckdb
+
 # DBT
 mini_dwh_dbt/target/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Mini DWH with PostgreSQL and dbt
+# Mini DWH with DuckDB and dbt
 
 This repository contains a minimal example of a data warehouse using
-[PostgreSQL](https://www.postgresql.org/) with transformation models managed by
+[DuckDB](https://duckdb.org/) with transformation models managed by
 [dbt](https://www.getdbt.com/). An orchestration script reads
 `pipeline_config.yml` at startup and schedules each data source
 individually. Before running the selected dbt models the configured fetch
@@ -18,6 +18,7 @@ function is executed for that source.
   executes each source on its defined schedule.
 - `mini_dwh_dbt/` is used as the working directory for all dbt commands
   executed by the orchestrator and Prefect flow.
+- `mini_dwh_dbt/data/warehouse.duckdb` - DuckDB file created when the pipeline runs.
 
 ## Configuration
 
@@ -70,6 +71,7 @@ make sure the CLI is executed in the `mini_dwh_dbt/` directory so that the
 
 ```bash
 cd mini_dwh_dbt
+mkdir -p data  # create the DuckDB directory if it doesn't exist
 dbt run -s models/bronze/orders_bronze.sql
 ```
 
@@ -84,10 +86,12 @@ docker compose up --build
 ```
 
 The Compose stack exposes two services: the orchestrator container and a
-PostgreSQL server accessible on `localhost:5432`. The orchestrator sets
-`DBT_PROFILES_DIR` automatically so dbt uses the bundled profile. Once the
-containers are running you can open a shell inside the DWH service if you
-want to execute additional `dbt` commands or inspect the database:
+DuckDB-Wasm Web UI reachable on `http://localhost:8080`. The service mounts
+the `data/` directory so the DuckDB file is available on the host. The
+orchestrator sets `DBT_PROFILES_DIR` automatically so dbt uses the bundled
+profile. Once the containers are running you can open a shell inside the DWH
+service if you want to execute additional `dbt` commands or inspect the
+database:
 
 ```bash
 docker compose exec dwh bash
@@ -133,11 +137,25 @@ poetry run prefect agent start -q default
 The Prefect UI, available at `http://127.0.0.1:4200`, shows the status of
 each run so you can keep track of your pipeline executions.
 
-## Database access
+## DuckDB-Wasm Web UI
 
-The PostgreSQL service persists its data in a Docker volume so the
-warehouse state is retained between runs. Connect with any PostgreSQL
-client using the credentials defined in `docker-compose.yml`.
+Docker Compose also starts a small service that hosts the official
+DuckDB-Wasm Web UI. Once the stack is running open
+`http://localhost:8080` in your browser. Use the **Open** button in the UI
+to load `data/warehouse.duckdb` from the repository and explore the
+database interactively.
+
+## Connecting with DBeaver
+
+You can also inspect the warehouse using the
+[DBeaver](https://dbeaver.io/) desktop application:
+
+1. Install and start DBeaver.
+2. Create a new connection and choose **DuckDB** as the database type.
+3. Browse to `mini_dwh_dbt/data/warehouse.duckdb` when prompted for the
+   database file.
+4. Finish the wizard to connect. Tables will appear in the navigator and
+   update automatically as the pipeline runs.
 
 ## Adding new data sources
 
@@ -164,21 +182,16 @@ poetry run python register_model.py my_model --activate
 
 ## dbt configuration
 
-The dbt profile in `mini_dwh_dbt/profiles.yml` is used by the orchestrator.
-It automatically sets
-`DBT_PROFILES_DIR` to use this profile. Connection details are configured via
-environment variables passed to the container.
+The dbt profile in `mini_dwh_dbt/profiles.yml` points to
+`mini_dwh_dbt/data/warehouse.duckdb`. The orchestrator automatically sets
+`DBT_PROFILES_DIR` to use this profile. You can override the database path by
+setting the `DUCKDB_PATH` environment variable.
 
 ```yaml
 mini_dwh:
   target: dev
   outputs:
     dev:
-      type: postgres
-      host: "{{ env_var('POSTGRES_HOST') }}"
-      port: "{{ env_var('POSTGRES_PORT') }}"
-      user: "{{ env_var('POSTGRES_USER') }}"
-      pass: "{{ env_var('POSTGRES_PASSWORD') }}"
-      dbname: "{{ env_var('POSTGRES_DB') }}"
-      schema: public
+      type: duckdb
+      path: "data/warehouse.duckdb"
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,25 +5,8 @@ services:
     volumes:
       - ./data:/app/data
     command: python orchestrator.py
-    environment:
-      POSTGRES_HOST: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: mini_dwh
-      POSTGRES_PORT: 5432
-    depends_on:
-      - postgres
 
-  postgres:
-    image: postgres:15
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: mini_dwh
+  webui:
+    image: ghcr.io/duckdb/duckdb-wasm-shell:latest
     ports:
-      - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
-volumes:
-  postgres_data:
+      - "8080:8080"

--- a/mini_dwh_dbt/profiles.yml
+++ b/mini_dwh_dbt/profiles.yml
@@ -2,11 +2,5 @@ mini_dwh:
   target: dev
   outputs:
     dev:
-      type: postgres
-      threads: 1
-      host: "{{ env_var('POSTGRES_HOST', 'localhost') }}"
-      port: "{{ env_var('POSTGRES_PORT', '5432') }}"
-      user: "{{ env_var('POSTGRES_USER', 'postgres') }}"
-      pass: "{{ env_var('POSTGRES_PASSWORD', 'postgres') }}"
-      dbname: "{{ env_var('POSTGRES_DB', 'mini_dwh') }}"
-      schema: public
+      type: duckdb
+      path: "data/warehouse.duckdb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,19 @@
 [tool.poetry]
 name = "mini-dwh"
 version = "0.1.0"
-description = "Mini data warehouse example using PostgreSQL and dbt"
+description = "Mini data warehouse example using DuckDB and dbt"
 authors = ["Your Name <you@example.com>"]
 package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
+duckdb = "*"
 schedule = "*"
 dbt-core = "*"
-dbt-postgres = "*"
+dbt-duckdb = "*"
 prefect = "*"
 pandas = "*"
 yfinance = "*"
-psycopg2-binary = "*"
 
 [tool.poetry.group.dev.dependencies]
 # Add dev dependencies here

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements exported from Poetry
+duckdb
 schedule
 dbt-core
-dbt-postgres
+dbt-duckdb
 pandas
 yfinance
 prefect
-psycopg2-binary


### PR DESCRIPTION
## Summary
- revert repository to use DuckDB instead of PostgreSQL
- document how to connect to the DuckDB database with DBeaver

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ca66bbb4483279b665b5760cafcd2