### PR TITLE
Fix DuckDB Web UI image source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     command: dagster dev -m dagster_pipeline --host 0.0.0.0
 
   webui:
-    image: ghcr.io/duckdb/duckdb-wasm-shell:latest
+    image: duckdb/duckdb-wasm-shell:latest
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- pull DuckDB web interface image from Docker Hub

## Testing
- `poetry --version`
- `poetry install` *(fails: cannot reach pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_685caa4839ac832781180a60b7448416