### PR TITLE
Update Docker compose to use GHCR image

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,11 @@ docker compose up --build
 ```
 
 The Compose stack exposes two services: the Dagster container and a
-DuckDB-Wasm Web UI reachable on `http://localhost:8080`. The service mounts
-the `data/` directory so the DuckDB file is available on the host. Dagster
+DuckDB-Wasm Web UI reachable on `http://localhost:8080`. The service is
+based on the
+[`ghcr.io/duckdb/duckdb-wasm-shell`](https://github.com/duckdb/duckdb-wasm)
+Docker image and mounts the `data/` directory so the DuckDB file is
+available on the host. Dagster
 sets `DBT_PROFILES_DIR` automatically so dbt uses the bundled profile. Once
 the containers are running you can open a shell inside the DWH
 service if you want to execute additional `dbt` commands or inspect the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
     command: dagster dev -m dagster_pipeline --host 0.0.0.0
 
   webui:
-    image: duckdb/duckdb-wasm-shell:latest
+    image: ghcr.io/duckdb/duckdb-wasm-shell:latest
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- use the `ghcr.io/duckdb/duckdb-wasm-shell` image for the Web UI
- document the new image in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cab3ddd1c83279e81f33f41e59880