### PR TITLE
Add script for optional GitHub docker login

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ dbt for transformations and Dagster for orchestration.
 ## Quick start
 
 1. Install [Docker](https://docs.docker.com/get-docker/).
-2. Build and run the stack:
+2. (Optional) Authenticate with GitHub and pre-pull the web UI image:
+
+   ```bash
+   ./login_and_pull.sh
+   ```
+
+3. Build and run the stack:
 
    ```bash
    docker compose up --build
    ```
 
-3. Access the running services:
+4. Access the running services:
    - Dagster UI: <http://localhost:3000>
    - DuckDB web UI: <http://localhost:8080>
    - dbt docs: <http://localhost:8081>

--- a/login_and_pull.sh
+++ b/login_and_pull.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Script to attempt GitHub Container Registry login and pull required image.
+# Failure to login or pull the image will not abort execution.
+
+IMAGE="ghcr.io/duckdb/duckdb-wasm-shell:latest"
+
+set +e  # Do not exit on errors so build continues
+
+echo "Attempting to log in to GitHub Container Registry (ghcr.io)..."
+docker login ghcr.io
+LOGIN_STATUS=$?
+
+if [ $LOGIN_STATUS -ne 0 ]; then
+    echo "Login failed. Continuing without authentication."
+fi
+
+echo "Attempting to pull $IMAGE ..."
+docker pull "$IMAGE"
+PULL_STATUS=$?
+
+if [ $PULL_STATUS -ne 0 ]; then
+    echo "Failed to pull $IMAGE. Continuing with build."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add `login_and_pull.sh` to optionally authenticate with GitHub and pull the web UI image
- document running the script in the quick start steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf7f0f7188327bd14b4447b0e67c6