### PR TITLE
Update quick-start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ dbt for transformations and Dagster for orchestration.
 ## Quick start
 
 1. Install [Docker](https://docs.docker.com/get-docker/).
-2. Build and run the stack:
+2. Generate the `poetry.lock` file:
+
+   ```bash
+   poetry lock
+   ```
+
+3. Build and run the stack:
 
    ```bash
    docker compose up --build
    ```
 
-3. Access the running services:
+4. Access the running services:
    - Dagster UI: <http://localhost:3000>
    - dbt docs: <http://localhost:8081>
 


### PR DESCRIPTION
## Summary
- add note about generating `poetry.lock` before building the Docker image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfe5f9cfc8327922f7a07c3eb5709