### PR TITLE
Fix DuckDB profile path

### DIFF
--- a/mini_dwh_dbt/profiles.yml
+++ b/mini_dwh_dbt/profiles.yml
@@ -3,4 +3,4 @@ mini_dwh:
   outputs:
     dev:
       type: duckdb
-      path: "data/warehouse.duckdb"
+      path: "../data/warehouse.duckdb"


### PR DESCRIPTION
## Summary
- fix DB path in dbt profile so the warehouse file is created under `data/`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cfdea9b388327a28fed475b5ec9a4