### PR TITLE
Fix dbt docs service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
 
   docs:
     build: .
-    command: bash -c "dbt docs generate --project-dir mini_dwh_dbt && dbt docs serve --port 8081 --address 0.0.0.0"
+    working_dir: /app/mini_dwh_dbt
+    command: bash -c "dbt docs generate && dbt docs serve --port 8081 --address 0.0.0.0"
     volumes:
       - ./data:/app/data
     ports:


### PR DESCRIPTION
## Summary
- ensure docs service runs from the dbt project directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685dadfe986c83279ff4e7869cd8de4f