### PR TITLE
Add oil and fertilizer commodities

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ dbt for transformations and Dagster for orchestration.
 The warehouse database is stored in `data/warehouse.duckdb`. Open this file in
 [DBeaver](https://dbeaver.io/) to explore tables created by dbt. Two sample
 sources are included: hourly commodity prices from Yahoo Finance and hourly
-weather data from the Open‑Meteo API. The `wheat_weather` model joins these
-datasets.
+weather data from the Open‑Meteo API. Commodity prices cover wheat, corn,
+soybeans, crude oil and a placeholder fertilizer index. The `wheat_weather`
+model joins these datasets.
 
 ## Editing models
 
@@ -45,7 +46,8 @@ poetry run python register_model.py <model_name> --activate   # or --deactivate
 - `dagster_pipeline.py` – Dagster job reading `pipeline_config.yml`.
 - `sources/` – Python modules for fetching raw data.
 - `mini_dwh_dbt/` – dbt project containing models and configuration.
-  - `sources/commodities.py` downloads futures prices.
+  - `sources/commodities.py` downloads futures prices for wheat, corn,
+    soybeans, crude oil and a fertilizer index.
   - `sources/weather.py` fetches hourly temperature observations.
 
 Start the stack with Docker, modify dbt models and watch the pipeline run!

--- a/sources/commodities.py
+++ b/sources/commodities.py
@@ -20,6 +20,10 @@ def fetch() -> None:
         "wheat": "ZW=F",
         "corn": "ZC=F",
         "soybeans": "ZS=F",
+        # Crude oil futures
+        "oil": "CL=F",
+        # TODO: Replace with a valid fertilizer price ticker
+        "fertilizer": "FTR.F",
     }
     end = datetime.utcnow()
     start = end - timedelta(days=720)


### PR DESCRIPTION
## Summary
- expand `commodities` source to include crude oil and a placeholder fertilizer index
- clarify in the README that commodity prices now include wheat, corn, soybeans, crude oil and fertilizer

## Testing
- `python -m sources.commodities` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685dafadbc208327a9bb40607589d2cc