### PR TITLE
Organize tables by schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ dbt for transformations and Dagster for orchestration.
    - dbt docs: <http://localhost:8081>
 
 The warehouse database is stored in `data/warehouse.duckdb`. Open this file in
-[DBeaver](https://dbeaver.io/) to explore tables created by dbt. Two sample
+[DBeaver](https://dbeaver.io/) to explore tables created by dbt. Tables are
+organized into `bronze`, `silver` and `gold` schemas according to their
+transformation stage. Two sample
 sources are included: hourly commodity prices from Yahoo Finance and hourly
 weather data from the Open‑Meteo API. Commodity prices cover wheat, corn,
 soybeans, crude oil and a placeholder fertilizer index. The `wheat_weather`

--- a/mini_dwh_dbt/dbt_project.yml
+++ b/mini_dwh_dbt/dbt_project.yml
@@ -12,8 +12,11 @@ target-path: 'target'
 models:
   mini_dwh:
     bronze:
+      +schema: bronze
       materialized: table
     silver:
+      +schema: silver
       materialized: table
     gold:
+      +schema: gold
       materialized: table


### PR DESCRIPTION
## Summary
- organize models into bronze, silver and gold schemas
- update docs to mention new schema setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685db3423ab88327abdde239b66fb2e7