### PR TITLE
Add extra data fetcher pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ dbt for transformations and Dagster for orchestration.
    - dbt docs: <http://localhost:8081>
 
 The warehouse database is stored in `data/warehouse.duckdb`. Open this file in
-[DBeaver](https://dbeaver.io/) to explore tables created by dbt. Two sample
+[DBeaver](https://dbeaver.io/) to explore tables created by dbt. Several sample
 sources are included: hourly commodity prices from Yahoo Finance and hourly
-weather data from the Open‑Meteo API. Commodity prices cover wheat, corn,
-soybeans, crude oil and a placeholder fertilizer index. The `wheat_weather`
-model joins these datasets.
+weather data from the Open‑Meteo API. Additional fetchers provide stock prices,
+currency exchange rates, short‑term weather forecasts and GDP figures from the
+World Bank. Commodity prices cover wheat, corn, soybeans, crude oil and a
+placeholder fertilizer index. The `wheat_weather` model joins the commodity and
+weather observations.
 
 ## Editing models
 
@@ -68,5 +70,9 @@ If no run configuration is supplied, the job falls back to the values defined in
   - `sources/commodities.py` downloads futures prices for wheat, corn,
     soybeans, crude oil and a fertilizer index.
   - `sources/weather.py` fetches hourly temperature observations.
+  - `sources/stocks.py` retrieves daily stock prices for a few tickers.
+  - `sources/exchange_rates.py` stores current USD exchange rates.
+  - `sources/weather_forecast.py` downloads a 7‑day weather forecast.
+  - `sources/world_bank.py` collects GDP data from the World Bank API.
 
 Start the stack with Docker, modify dbt models and watch the pipeline run!

--- a/pipeline_config.yml
+++ b/pipeline_config.yml
@@ -19,3 +19,19 @@ sources:
     schedule: "hourly"
     models:
       - wheat_weather
+  - name: stocks
+    fetcher: sources.stocks.fetch
+    schedule: "daily"
+    models: []
+  - name: exchange_rates
+    fetcher: sources.exchange_rates.fetch
+    schedule: "daily"
+    models: []
+  - name: weather_forecast
+    fetcher: sources.weather_forecast.fetch
+    schedule: "daily"
+    models: []
+  - name: world_bank_gdp
+    fetcher: sources.world_bank.fetch
+    schedule: "daily"
+    models: []

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -1,1 +1,4 @@
-"""Data source fetcher modules."""
+"""Data source fetcher modules for the demo warehouse."""
+
+# Modules are discovered via their ``fetch`` functions referenced in
+# ``pipeline_config.yml``.

--- a/sources/exchange_rates.py
+++ b/sources/exchange_rates.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "exchange_rates.csv"
+)
+
+
+def fetch() -> None:
+    """Download latest USD exchange rates."""
+    url = "https://api.exchangerate.host/latest?base=USD"
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    rates = data.get("rates", {})
+    timestamp = datetime.now(timezone.utc)
+    currencies = ["EUR", "GBP", "JPY"]
+    rows = [
+        {"timestamp": timestamp, "currency": c, "rate": rates.get(c)}
+        for c in currencies
+        if c in rates
+    ]
+    if not rows:
+        return
+    df = pd.DataFrame(rows)
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(DATA_PATH, index=False)
+
+
+if __name__ == "__main__":
+    fetch()

--- a/sources/stocks.py
+++ b/sources/stocks.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import yfinance as yf
+
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "stock_prices.csv"
+)
+
+
+def fetch() -> None:
+    """Download recent stock prices using yfinance."""
+    tickers = {
+        "AAPL": "AAPL",
+        "GOOG": "GOOG",
+        "MSFT": "MSFT",
+    }
+    end = datetime.utcnow()
+    start = end - timedelta(days=30)
+    frames = []
+    for name, ticker in tickers.items():
+        df = yf.download(ticker, start=start, end=end, interval="1d")
+        if df.empty:
+            continue
+        df.index.name = "timestamp"
+        df = df.reset_index()
+        price_col = "Close" if "Close" in df.columns else "Adj Close"
+        df.rename(columns={price_col: "price"}, inplace=True)
+        df["ticker"] = name
+        frames.append(df[["timestamp", "price", "ticker"]])
+    if not frames:
+        return
+    result = pd.concat(frames)
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(DATA_PATH, index=False)
+
+
+if __name__ == "__main__":
+    fetch()

--- a/sources/weather_forecast.py
+++ b/sources/weather_forecast.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "weather_forecast.csv"
+)
+
+
+def fetch() -> None:
+    """Download a 7-day weather forecast using the open-meteo API."""
+    url = (
+        "https://api.open-meteo.com/v1/forecast?latitude=41.8781"
+        "&longitude=-87.6298&hourly=temperature_2m&forecast_days=7"
+    )
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    hourly = data.get("hourly", {})
+    if not hourly:
+        return
+    df = pd.DataFrame({
+        "timestamp": pd.to_datetime(hourly.get("time", [])),
+        "temperature_c": hourly.get("temperature_2m", []),
+    })
+    if df.empty:
+        return
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(DATA_PATH, index=False)
+
+
+if __name__ == "__main__":
+    fetch()

--- a/sources/world_bank.py
+++ b/sources/world_bank.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "world_bank_gdp.csv"
+)
+
+
+def fetch() -> None:
+    """Download recent GDP data from the World Bank."""
+    countries = ["USA", "CAN", "MEX"]
+    frames = []
+    for country in countries:
+        url = (
+            f"https://api.worldbank.org/v2/country/{country}/"
+            "indicator/NY.GDP.MKTP.CD?format=json"
+        )
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        values = data[1] if len(data) > 1 else []
+        for entry in values[:10]:
+            year = entry.get("date")
+            value = entry.get("value")
+            if value is None:
+                continue
+            frames.append({
+                "country": country,
+                "year": int(year),
+                "gdp_usd": float(value),
+            })
+    if not frames:
+        return
+    df = pd.DataFrame(frames)
+    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(DATA_PATH, index=False)
+
+
+if __name__ == "__main__":
+    fetch()


### PR DESCRIPTION
## Summary
- add fetchers for stocks, exchange rates, weather forecasts and GDP data
- document new pipelines in the README
- register new sources in `pipeline_config.yml`

## Testing
- `python -m py_compile sources/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685db5460284832797dc673bc71c66f6