### PR TITLE
Update paths for external CSV storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,24 @@ dbt for transformations and Dagster for orchestration.
    poetry lock
    ```
 
-3. Build and run the stack:
+3. Create a directory for raw CSV files next to the project:
+
+   ```bash
+   mkdir ../external_data
+   ```
+
+4. Build and run the stack:
 
    ```bash
    docker compose up --build
    ```
 
-4. Access the running services:
+5. Access the running services:
    - Dagster UI: <http://localhost:3000>
    - dbt docs: <http://localhost:8081>
 
-The warehouse database is stored in `data/warehouse.duckdb`. Open this file in
+The warehouse database is stored in `data/warehouse.duckdb`. Raw CSV files are
+written to `../external_data`. Open the database in
 [DBeaver](https://dbeaver.io/) to explore tables created by dbt. Several sample
 sources are included: hourly commodity prices from Yahoo Finance and hourly
 weather data from the Open‑Meteo API. Additional fetchers provide stock prices,
@@ -67,6 +74,7 @@ If no run configuration is supplied, the job falls back to the values defined in
 - `dagster_pipeline.py` – Dagster job reading `pipeline_config.yml`.
 - `sources/` – Python modules for fetching raw data.
 - `dbt/` – dbt project containing models and configuration.
+  - Raw CSV files are stored one level above the project in `../external_data`.
   - `sources/commodities.py` downloads futures prices for wheat, corn,
     soybeans, crude oil and a fertilizer index.
   - `sources/weather.py` fetches hourly temperature observations.

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -5,7 +5,7 @@ config-version: 2
 profile: 'dwh'
 
 model-paths: ['models']
-seed-paths: ['seeds']
+seed-paths: ['seeds', '../../external_data']
 
 target-path: 'target'
 

--- a/sources/README.md
+++ b/sources/README.md
@@ -1,6 +1,6 @@
 # Source Modules
 
-This package contains modules responsible for fetching raw datasets used by the data warehouse. Each module exposes a single `fetch()` function which downloads data and writes it to the appropriate location under `dbt/seeds/`.
+This package contains modules responsible for fetching raw datasets used by the data warehouse. Each module exposes a single `fetch()` function which downloads data and writes it to ``../external_data`` (relative to the project root).
 
 To add a new source:
 

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -2,3 +2,10 @@
 
 # Modules are discovered via their ``fetch`` functions referenced in
 # ``pipeline_config.yml``.
+
+from pathlib import Path
+
+# Raw CSV files are stored outside the repository in a sibling directory.
+# ``EXTERNAL_DATA_DIR`` resolves to ``../external_data`` relative to the
+# repository root.
+EXTERNAL_DATA_DIR = Path(__file__).resolve().parent.parent.parent / "external_data"

--- a/sources/commodities.py
+++ b/sources/commodities.py
@@ -1,17 +1,12 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import yfinance as yf
 
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "commodity_prices.csv"
-)
+DATA_PATH = EXTERNAL_DATA_DIR / "commodity_prices.csv"
 
 
 def fetch() -> None:

--- a/sources/exchange_rates.py
+++ b/sources/exchange_rates.py
@@ -1,16 +1,12 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
+from . import EXTERNAL_DATA_DIR
+
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "exchange_rates.csv"
-)
+DATA_PATH = EXTERNAL_DATA_DIR / "exchange_rates.csv"
 
 
 def fetch() -> None:

--- a/sources/stocks.py
+++ b/sources/stocks.py
@@ -1,16 +1,12 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from . import EXTERNAL_DATA_DIR
+
 import pandas as pd
 import yfinance as yf
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "stock_prices.csv"
-)
+DATA_PATH = EXTERNAL_DATA_DIR / "stock_prices.csv"
 
 
 def fetch() -> None:

--- a/sources/weather.py
+++ b/sources/weather.py
@@ -1,15 +1,11 @@
 from datetime import datetime, timedelta
 from pathlib import Path
+
+from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "weather.csv"
-)
+DATA_PATH = EXTERNAL_DATA_DIR / "weather.csv"
 
 
 def fetch() -> None:

--- a/sources/weather_forecast.py
+++ b/sources/weather_forecast.py
@@ -1,15 +1,10 @@
 from pathlib import Path
 
+from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "weather_forecast.csv"
-)
+DATA_PATH = EXTERNAL_DATA_DIR / "weather_forecast.csv"
 
 
 def fetch() -> None:

--- a/sources/world_bank.py
+++ b/sources/world_bank.py
@@ -1,15 +1,10 @@
 from pathlib import Path
 
+from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "world_bank_gdp.csv"
-)
+DATA_PATH = EXTERNAL_DATA_DIR / "world_bank_gdp.csv"
 
 
 def fetch() -> None:


### PR DESCRIPTION
## Summary
- place all CSV seed data in `../external_data`
- document the new directory in the README files
- reference the new directory in the sources package and dbt config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685db5aa06f483278b85514a45a987b8