### PR TITLE
Fix dbt docs serve flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   docs:
     build: .
     working_dir: /app/dbt
-    command: bash -c "dbt docs generate && dbt docs serve --port 8081 --address 0.0.0.0"
+    command: bash -c "dbt docs generate && dbt docs serve --port 8081 --host 0.0.0.0"
 
     volumes:
       - ./data:/app/data


### PR DESCRIPTION
## Summary
- fix outdated dbt flag in docker compose

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dba9b6b7c8327a4cac6188217dc52