### PR TITLE
Add DuckDB cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,13 @@ If no run configuration is supplied, the job falls back to the values defined in
   - `sources/world_bank.py` collects GDP data from the World Bank API.
 
 Start the stack with Docker, modify dbt models and watch the pipeline run!
+
+## Database cleanup
+
+Old tables may accumulate in `data/warehouse.duckdb` when models are renamed or removed.
+Run the `cleanup_duckdb.py` helper to drop any tables that are not backed by a
+dbt model or seed:
+
+```bash
+python cleanup_duckdb.py
+```

--- a/cleanup_duckdb.py
+++ b/cleanup_duckdb.py
@@ -1,0 +1,51 @@
+"""Remove unused tables from the DuckDB warehouse."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import duckdb
+
+DBT_DIR = Path(__file__).parent / "dbt"
+DB_PATH = Path(__file__).parent / "data" / "warehouse.duckdb"
+
+
+def list_models() -> set[str]:
+    """Return model names based on SQL files under ``dbt/models``."""
+    model_dir = DBT_DIR / "models"
+    return {p.stem for p in model_dir.rglob("*.sql")}
+
+
+def list_seeds() -> set[str]:
+    """Return seed names based on files under ``dbt/seeds``."""
+    seed_dir = DBT_DIR / "seeds"
+    seeds = set()
+    for p in seed_dir.rglob("*.*"):
+        if p.suffix.lower() in {".csv", ".tsv", ".parquet"}:
+            seeds.add(p.stem)
+    return seeds
+
+
+def used_tables() -> set[str]:
+    """Set of table names managed by dbt models or seeds."""
+    return list_models() | list_seeds()
+
+
+def db_tables(con: duckdb.DuckDBPyConnection) -> set[str]:
+    rows = con.execute(
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def cleanup() -> None:
+    con = duckdb.connect(DB_PATH)
+    managed = used_tables()
+    existing = db_tables(con)
+    for table in sorted(existing - managed):
+        con.execute(f'DROP TABLE "{table}"')
+        print(f"Dropped {table}")
+    con.close()
+
+
+if __name__ == "__main__":
+    cleanup()


### PR DESCRIPTION
## Summary
- add `cleanup_duckdb.py` to drop unused tables from the DuckDB file
- mention new helper in README

## Testing
- `python -m py_compile cleanup_duckdb.py`

------
https://chatgpt.com/codex/tasks/task_e_685dbe2c36fc8327bb1029c0dac4ab68