### PR TITLE
Fix Dagster config schema for optional models

### DIFF
--- a/dagster_pipeline.py
+++ b/dagster_pipeline.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 
 import yaml
-from dagster import Definitions, ScheduleDefinition, job, op, Field
+from dagster import Definitions, ScheduleDefinition, job, op, Field, Noneable
 
 DBT_DIR = Path(__file__).parent / "dbt"
 CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
@@ -36,7 +36,7 @@ def fetch_data(context) -> bool:
 
 
 @op(
-    config_schema={"models": Field([str], is_required=False, default_value=None)}
+    config_schema={"models": Field(Noneable([str]), is_required=False, default_value=None)}
 )
 def run_dbt_pipeline(context, _start: bool) -> None:
     """Run dbt for the configured models."""


### PR DESCRIPTION
## Summary
- allow specifying `None` for `models` in Dagster op configuration

## Testing
- `python -m py_compile dagster_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_685dbf3b4c4c83278cd840e81b290cfc