### PR TITLE
Add Lightdash visualization service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ dbt for transformations and Dagster for orchestration.
 5. Access the running services:
    - Dagster UI: <http://localhost:3000>
    - dbt docs: <http://localhost:8081>
+   - Lightdash: <http://localhost:8080>
 
 The warehouse database is stored in `data/warehouse.duckdb`. Raw CSV files are
 written to `../external_data`. Open the database in
@@ -127,8 +128,14 @@ If no run configuration is supplied, the job falls back to the values defined in
   - `sources/weather.py` fetches hourly temperature observations.
   - `sources/stocks.py` retrieves daily stock prices for a few tickers.
   - `sources/exchange_rates.py` stores current USD exchange rates.
-  - `sources/weather_forecast.py` downloads a 7‑day weather forecast.
-  - `sources/world_bank.py` collects GDP data from the World Bank API.
+- `sources/weather_forecast.py` downloads a 7‑day weather forecast.
+- `sources/world_bank.py` collects GDP data from the World Bank API.
+
+## Data visualization with Lightdash
+
+Lightdash reads the dbt project and lets you define metrics and dashboards as
+YAML files alongside your models. The service runs on <http://localhost:8080>.
+Create an account when prompted and start exploring the warehouse.
 
 Start the stack with Docker, modify dbt models and watch the pipeline run!
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,33 @@ services:
     environment:
       DBT_PROFILES_DIR: /app/dbt
 
+  lightdash_db:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: lightdash
+      POSTGRES_PASSWORD: lightdash
+      POSTGRES_DB: lightdash
+    volumes:
+      - lightdash_db:/var/lib/postgresql/data
+
+  lightdash:
+    image: lightdash/lightdash:latest
+    depends_on:
+      - lightdash_db
+    volumes:
+      - ./dbt:/usr/app/dbt
+      - ./data:/usr/app/data
+    environment:
+      LIGHTDASH_SECRET: supersecret
+      PGHOST: lightdash_db
+      PGPORT: 5432
+      PGUSER: lightdash
+      PGPASSWORD: lightdash
+      PGDATABASE: lightdash
+      DBT_PROJECT_DIR: /usr/app/dbt
+    ports:
+      - "8080:8080"
+
   docs:
     build: .
     working_dir: /app/dbt
@@ -21,3 +48,6 @@ services:
       - "8081:8081"
     environment:
       DBT_PROFILES_DIR: /app/dbt
+
+volumes:
+  lightdash_db:


### PR DESCRIPTION
## Summary
- start Lightdash with Postgres in docker-compose
- show Lightdash port in README
- document Lightdash usage

## Testing
- `pytest -q`
- ❌ `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685dc36283f48327a348fb1a0970f3df