### PR TITLE
Revert CSV storage back to project seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,19 @@ dbt for transformations and Dagster for orchestration.
    poetry lock
    ```
 
-3. Create a directory for raw CSV files next to the project:
-
-   ```bash
-   mkdir ../external_data
-   ```
-
-4. Build and run the stack:
+3. Build and run the stack:
 
    ```bash
    docker compose up --build
    ```
 
-5. Access the running services:
+4. Access the running services:
    - Dagster UI: <http://localhost:3000>
    - dbt docs: <http://localhost:8081>
    - Lightdash: <http://localhost:8080>
 
 The warehouse database is stored in `data/warehouse.duckdb`. Raw CSV files are
-written to `../external_data`. Open the database in
+written to `dbt/seeds/external`. Open the database in
 [DBeaver](https://dbeaver.io/) to explore tables created by dbt. Several sample
 sources are included: hourly commodity prices from Yahoo Finance and hourly
 weather data from the Open‑Meteo API. Additional fetchers provide stock prices,
@@ -45,7 +39,7 @@ The typical workflow when extending the warehouse is:
 
 1. **Pull raw data**
    - Implement a new module under `sources/` exposing a `fetch()` function.
-   - Run the fetcher directly to download data into `../external_data`:
+  - Run the fetcher directly to download data into `dbt/seeds/external`:
 
      ```bash
      poetry run python -m sources.your_source
@@ -122,7 +116,7 @@ If no run configuration is supplied, the job falls back to the values defined in
 - `run_pipeline.py` – helper script to fetch data and run dbt once.
 - `sources/` – Python modules for fetching raw data.
 - `dbt/` – dbt project containing models and configuration.
-  - Raw CSV files are stored one level above the project in `../external_data`.
+  - Raw CSV files are stored under `dbt/seeds/external`.
   - `sources/commodities.py` downloads futures prices for wheat, corn,
     soybeans, crude oil and a fertilizer index.
   - `sources/weather.py` fetches hourly temperature observations.

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -5,7 +5,7 @@ config-version: 2
 profile: 'dwh'
 
 model-paths: ['models']
-seed-paths: ['seeds', '../../external_data']
+seed-paths: ['seeds']
 
 target-path: 'target'
 

--- a/sources/README.md
+++ b/sources/README.md
@@ -1,6 +1,6 @@
 # Source Modules
 
-This package contains modules responsible for fetching raw datasets used by the data warehouse. Each module exposes a single `fetch()` function which downloads data and writes it to ``../external_data`` (relative to the project root).
+This package contains modules responsible for fetching raw datasets used by the data warehouse. Each module exposes a single `fetch()` function which downloads data and writes it to the appropriate location under `dbt/seeds/`.
 
 To add a new source:
 

--- a/sources/__init__.py
+++ b/sources/__init__.py
@@ -2,10 +2,3 @@
 
 # Modules are discovered via their ``fetch`` functions referenced in
 # ``pipeline_config.yml``.
-
-from pathlib import Path
-
-# Raw CSV files are stored outside the repository in a sibling directory.
-# ``EXTERNAL_DATA_DIR`` resolves to ``../external_data`` relative to the
-# repository root.
-EXTERNAL_DATA_DIR = Path(__file__).resolve().parent.parent.parent / "external_data"

--- a/sources/commodities.py
+++ b/sources/commodities.py
@@ -1,12 +1,16 @@
 from datetime import datetime, timedelta
 from pathlib import Path
-
-from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import yfinance as yf
 
 
-DATA_PATH = EXTERNAL_DATA_DIR / "commodity_prices.csv"
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "commodity_prices.csv"
+)
 
 
 def fetch() -> None:

--- a/sources/exchange_rates.py
+++ b/sources/exchange_rates.py
@@ -1,12 +1,16 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import EXTERNAL_DATA_DIR
-
 import pandas as pd
 import requests
 
-DATA_PATH = EXTERNAL_DATA_DIR / "exchange_rates.csv"
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "exchange_rates.csv"
+)
 
 
 def fetch() -> None:

--- a/sources/stocks.py
+++ b/sources/stocks.py
@@ -1,12 +1,16 @@
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from . import EXTERNAL_DATA_DIR
-
 import pandas as pd
 import yfinance as yf
 
-DATA_PATH = EXTERNAL_DATA_DIR / "stock_prices.csv"
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "stock_prices.csv"
+)
 
 
 def fetch() -> None:

--- a/sources/weather.py
+++ b/sources/weather.py
@@ -1,11 +1,15 @@
 from datetime import datetime, timedelta
 from pathlib import Path
-
-from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import requests
 
-DATA_PATH = EXTERNAL_DATA_DIR / "weather.csv"
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "weather.csv"
+)
 
 
 def fetch() -> None:

--- a/sources/weather_forecast.py
+++ b/sources/weather_forecast.py
@@ -1,10 +1,14 @@
 from pathlib import Path
-
-from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import requests
 
-DATA_PATH = EXTERNAL_DATA_DIR / "weather_forecast.csv"
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "weather_forecast.csv"
+)
 
 
 def fetch() -> None:

--- a/sources/world_bank.py
+++ b/sources/world_bank.py
@@ -1,10 +1,14 @@
 from pathlib import Path
-
-from . import EXTERNAL_DATA_DIR
 import pandas as pd
 import requests
 
-DATA_PATH = EXTERNAL_DATA_DIR / "world_bank_gdp.csv"
+DATA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dbt"
+    / "seeds"
+    / "external"
+    / "world_bank_gdp.csv"
+)
 
 
 def fetch() -> None:


### PR DESCRIPTION
## Summary
- keep all CSV seeds in the project
- revert dbt seed path configuration
- update source fetchers to write under `dbt/seeds/external`
- remove external data references from docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685dc2cbe1f0832784fd99d873bb0445