### PR TITLE
Fix Lightdash start error by enabling S3 mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Lightdash reads the dbt project and lets you define metrics and dashboards as
 YAML files alongside your models. The service runs on <http://localhost:8080>.
 Create an account when prompted and start exploring the warehouse.
 
+The `docker-compose.yml` file enables a built-in S3 mock so no external S3
+configuration is required. If you upgrade Lightdash and encounter an error about
+missing S3 settings, ensure that the `S3_MOCK` environment variable is set to
+`"true"` for the Lightdash service.
+
 Start the stack with Docker, modify dbt models and watch the pipeline run!
 
 ## Database cleanup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,10 @@ services:
       PGPASSWORD: lightdash
       PGDATABASE: lightdash
       DBT_PROJECT_DIR: /usr/app/dbt
+      # Use a built-in local S3 server for development to avoid extra
+      # configuration. This prevents the runtime error about missing S3
+      # settings when starting the Lightdash container.
+      S3_MOCK: "true"
     ports:
       - "8080:8080"
 


### PR DESCRIPTION
## Summary
- use built‑in S3 mock in the Lightdash service
- document the S3 mock requirement in the README

## Testing
- `python -m py_compile cleanup_duckdb.py dagster_pipeline.py register_model.py run_pipeline.py $(git ls-files '*.py' | tr '\n' ' ')`


------
https://chatgpt.com/codex/tasks/task_e_685dcba9f30083279e0e9992d26c1908