### PR TITLE
Fix docs seed dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ dbt for transformations and Dagster for orchestration.
    docker compose up --build
    ```
 
+   Sample seed files are included under `dbt/seeds/external` so the docs and
+   Lightdash containers can start without fetching data. Run the fetcher scripts
+   described below to refresh these CSVs with real data.
+
 4. Access the running services:
 
    - Dagster UI: <http://localhost:3000>

--- a/dbt/seeds/external/commodity_prices.csv
+++ b/dbt/seeds/external/commodity_prices.csv
@@ -1,0 +1,2 @@
+timestamp,price,commodity
+2024-01-01T00:00:00Z,100,wheat

--- a/dbt/seeds/external/weather.csv
+++ b/dbt/seeds/external/weather.csv
@@ -1,0 +1,2 @@
+timestamp,temperature_c
+2024-01-01T00:00:00Z,0


### PR DESCRIPTION
## Summary
- add minimal seed data so dbt docs builds
- document bundled seeds in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcd3e00848327bd9892288f4f10ec