### PR TITLE
Add S3 fallback variables for Lightdash

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ Create an account when prompted and start exploring the warehouse.
 The `docker-compose.yml` file enables a built-in S3 mock so no external S3
 configuration is required. If you upgrade Lightdash and encounter an error about
 missing S3 settings, ensure that the `S3_MOCK` environment variable is set to
-`"true"` for the Lightdash service.
+`"true"` for the Lightdash service. Some versions also require placeholder S3
+variables even when the mock is enabled. These are provided in the compose file
+with default values so Lightdash starts without additional setup.
 
 Start the stack with Docker, modify dbt models and watch the pipeline run!
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,15 @@ services:
       # configuration. This prevents the runtime error about missing S3
       # settings when starting the Lightdash container.
       S3_MOCK: "true"
+      # Provide explicit S3 parameters to satisfy newer Lightdash versions
+      # that require these variables even when using the built-in mock.
+      S3_ENDPOINT: http://localhost:9000
+      S3_BUCKET: lightdash
+      S3_REGION: us-east-1
+      S3_ACCESS_KEY_ID: minio
+      S3_SECRET_ACCESS_KEY: minio123
     ports:
-      - "8080:8080"
+        - "8080:8080"
 
   docs:
     build: .


### PR DESCRIPTION
## Summary
- add explicit S3 settings in `docker-compose.yml`
- document new Lightdash requirement for placeholder S3 variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dcef315f883279c00ae61c63b7e4d