### PR TITLE
Fix dbt invocation in pipeline

### DIFF
--- a/dagster_pipeline.py
+++ b/dagster_pipeline.py
@@ -49,32 +49,30 @@ def run_dbt_pipeline(context, _start: bool) -> None:
         models = list(active_models(cfg))
         context.log.info("Using active models from config: %s", models)
     download_seeds(DBT_DIR / "seeds" / "external")
+    # Use the ``dbt`` command directly rather than ``python -m dbt``. Some
+    # environments (including the Docker image used for this project) do not
+    # provide a ``__main__`` module for dbt which causes ``python -m dbt`` to
+    # exit with status 1. Invoking the ``dbt`` entrypoint avoids this problem.
     subprocess.run([
-        sys.executable,
-        "-m",
         "dbt",
         "seed",
     ], check=True, cwd=DBT_DIR)
     if models:
         subprocess.run([
-            sys.executable,
-            "-m",
             "dbt",
             "run",
             "-s",
             *models,
         ], check=True, cwd=DBT_DIR)
         subprocess.run([
-            sys.executable,
-            "-m",
             "dbt",
             "test",
             "-s",
             *models,
         ], check=True, cwd=DBT_DIR)
     else:
-        subprocess.run([sys.executable, "-m", "dbt", "run"], check=True, cwd=DBT_DIR)
-        subprocess.run([sys.executable, "-m", "dbt", "test"], check=True, cwd=DBT_DIR)
+        subprocess.run(["dbt", "run"], check=True, cwd=DBT_DIR)
+        subprocess.run(["dbt", "test"], check=True, cwd=DBT_DIR)
 
 
 @job

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -33,32 +33,28 @@ def fetch(fetcher: str) -> None:
 
 def run_dbt(models: list[str] | None) -> None:
     download_seeds(DBT_DIR / "seeds" / "external")
+    # ``python -m dbt`` fails in some environments because dbt does not expose
+    # a ``__main__`` module. Use the ``dbt`` command-line entrypoint instead.
     subprocess.run([
-        sys.executable,
-        "-m",
         "dbt",
         "seed",
     ], check=True, cwd=DBT_DIR)
     if models:
         subprocess.run([
-            sys.executable,
-            "-m",
             "dbt",
             "run",
             "-s",
             *models,
         ], check=True, cwd=DBT_DIR)
         subprocess.run([
-            sys.executable,
-            "-m",
             "dbt",
             "test",
             "-s",
             *models,
         ], check=True, cwd=DBT_DIR)
     else:
-        subprocess.run([sys.executable, "-m", "dbt", "run"], check=True, cwd=DBT_DIR)
-        subprocess.run([sys.executable, "-m", "dbt", "test"], check=True, cwd=DBT_DIR)
+        subprocess.run(["dbt", "run"], check=True, cwd=DBT_DIR)
+        subprocess.run(["dbt", "test"], check=True, cwd=DBT_DIR)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- fix Dagster job to call `dbt` entrypoint instead of `python -m dbt`
- update the standalone `run_pipeline.py` runner accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd8f20eb08327840d44f6fd617b71