### PR TITLE
Replace Helm with Superset

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ dbt for transformations and Dagster for orchestration.
    ```
 
    Sample seed files are included under `dbt/seeds/external` so the docs and
-   Helm containers can start without fetching data. Run the fetcher scripts
+   Superset containers can start without fetching data. Run the fetcher scripts
    described below to refresh these CSVs with real data.
 
 4. Access the running services:
 
    - Dagster UI: <http://localhost:3000>
    - dbt docs: <http://localhost:8081>
-   - Helm: <http://localhost:8080>
+   - Superset: <http://localhost:8080>
 
 The warehouse database is stored in `data/warehouse.duckdb`. Raw CSV files are
 uploaded to a Minio S3 bucket named `warehouse`. Open the database in
@@ -134,13 +134,13 @@ If no run configuration is supplied, the job falls back to the values defined in
 - `sources/weather_forecast.py` downloads a 7‑day weather forecast.
 - `sources/world_bank.py` collects GDP data from the World Bank API.
 
-## Data visualization with Helm
+## Data visualization with Superset
 
-Helm provides a Redash-based interface for exploring your data. The service
+Superset provides an intuitive interface for exploring your data. The service
 runs on <http://localhost:8080>. Create an account when prompted and start
 exploring the warehouse.
 
-CSV files and Helm assets are stored in a Minio object store included in the
+CSV files and Superset assets are stored in a Minio object store included in the
 Docker stack. Access the Minio console at <http://localhost:9001> using
 ``minio`` / ``minio123``.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,27 +25,29 @@ services:
       S3_ENDPOINT: http://minio:9000
       S3_BUCKET: warehouse
 
-  helm_db:
+  superset_db:
     image: postgres:13
     environment:
-      POSTGRES_USER: helm
-      POSTGRES_PASSWORD: helm
-      POSTGRES_DB: helm
+      POSTGRES_USER: superset
+      POSTGRES_PASSWORD: superset
+      POSTGRES_DB: superset
     volumes:
-      - helm_db:/var/lib/postgresql/data
+      - superset_db:/var/lib/postgresql/data
 
-  helm:
-    image: helm/helm:latest
+  superset_cache:
+    image: redis:latest
+
+  superset:
+    image: apache/superset:latest
     depends_on:
-      - helm_db
+      - superset_db
+      - superset_cache
     environment:
-      PGHOST: helm_db
-      PGPORT: 5432
-      PGUSER: helm
-      PGPASSWORD: helm
-      PGDATABASE: helm
+      SUPERSET_SECRET_KEY: superset-secret
+      SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@superset_db:5432/superset
+      REDIS_HOST: superset_cache
     ports:
-        - "8080:8080"
+      - "8080:8088"
 
   docs:
     build: .
@@ -60,5 +62,6 @@ services:
       DBT_PROFILES_DIR: /app/dbt
 
 volumes:
-  helm_db:
+  superset_db:
   minio_data:
+  superset_cache:


### PR DESCRIPTION
## Summary
- swap Helm for Superset in the docker compose setup
- update documentation to reference Superset instead of Helm

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ddd1c17a083279926e6e0714f923b