### PR TITLE
Improve dbt command execution

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -13,6 +13,32 @@ DBT_DIR = Path(__file__).parent / "dbt"
 CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
 
 
+def _run_dbt(args: list[str]) -> None:
+    """Execute a dbt command with a fallback to ``python -m dbt``.
+
+    Raises ``RuntimeError`` if the command fails or dbt is not installed."""
+    commands = [["dbt", *args], [sys.executable, "-m", "dbt", *args]]
+    last_error: Exception | None = None
+    for cmd in commands:
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=DBT_DIR,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            last_error = exc
+            continue
+        if result.returncode == 0:
+            return
+        last_error = RuntimeError(
+            f"{' '.join(cmd)} failed with code {result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+    if last_error:
+        raise last_error
+
+
 def load_config() -> dict:
     with open(CONFIG_FILE) as f:
         return yaml.safe_load(f) or {}
@@ -33,28 +59,13 @@ def fetch(fetcher: str) -> None:
 
 def run_dbt(models: list[str] | None) -> None:
     download_seeds(DBT_DIR / "seeds" / "external")
-    # ``python -m dbt`` fails in some environments because dbt does not expose
-    # a ``__main__`` module. Use the ``dbt`` command-line entrypoint instead.
-    subprocess.run([
-        "dbt",
-        "seed",
-    ], check=True, cwd=DBT_DIR)
+    _run_dbt(["seed"])
     if models:
-        subprocess.run([
-            "dbt",
-            "run",
-            "-s",
-            *models,
-        ], check=True, cwd=DBT_DIR)
-        subprocess.run([
-            "dbt",
-            "test",
-            "-s",
-            *models,
-        ], check=True, cwd=DBT_DIR)
+        _run_dbt(["run", "-s", *models])
+        _run_dbt(["test", "-s", *models])
     else:
-        subprocess.run(["dbt", "run"], check=True, cwd=DBT_DIR)
-        subprocess.run(["dbt", "test"], check=True, cwd=DBT_DIR)
+        _run_dbt(["run"])
+        _run_dbt(["test"])
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add a helper to detect and execute `dbt` via CLI or `python -m dbt`
- use this helper in Dagster and standalone pipeline scripts

## Testing
- `python -m py_compile dagster_pipeline.py run_pipeline.py register_model.py cleanup_duckdb.py s3_utils.py $(find sources -name '*.py')`
- `python run_pipeline.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_685de0bb2ef48327ad61da5cd871e581