### PR TITLE
Refactor shared dbt utilities

### DIFF
--- a/cleanup_duckdb.py
+++ b/cleanup_duckdb.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 import duckdb
 
-DBT_DIR = Path(__file__).parent / "dbt"
+from utils import DBT_DIR
+
 DB_PATH = Path(__file__).parent / "data" / "warehouse.duckdb"
 
 

--- a/register_model.py
+++ b/register_model.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import argparse
 import yaml
-from pathlib import Path
 
-
-CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
+from utils import CONFIG_FILE
 
 
 def load_config() -> dict:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import yaml
+
+DBT_DIR = Path(__file__).parent / "dbt"
+CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
+
+
+def _run_dbt(args: list[str]) -> None:
+    """Execute a dbt command with a fallback to ``python -m dbt``."""
+    commands = [["dbt", *args], [sys.executable, "-m", "dbt", *args]]
+    last_error: Exception | None = None
+    for cmd in commands:
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=DBT_DIR,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            last_error = exc
+            continue
+        if result.returncode == 0:
+            return
+        last_error = RuntimeError(
+            f"{' '.join(cmd)} failed with code {result.returncode}\n{result.stdout}\n{result.stderr}"
+        )
+    if last_error:
+        raise last_error
+
+
+def load_config() -> dict:
+    with open(CONFIG_FILE) as f:
+        return yaml.safe_load(f) or {}
+
+
+def active_models(cfg: dict) -> set[str]:
+    return {m.get("name") for m in cfg.get("models", []) if m.get("active")}


### PR DESCRIPTION
## Summary
- centralize dbt helpers in `utils.py`
- reuse common helpers across scripts

## Testing
- `python -m py_compile run_pipeline.py dagster_pipeline.py register_model.py cleanup_duckdb.py utils.py s3_utils.py sources/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685de44657408327b456757ac92c93fc