### PR TITLE
Fix dbt CLI invocation

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -17,7 +17,9 @@ def _run_dbt(args: list[str]) -> None:
     """Execute a dbt command with a fallback to ``python -m dbt``.
 
     Raises ``RuntimeError`` if the command fails or dbt is not installed."""
-    commands = [["dbt", *args], [sys.executable, "-m", "dbt", *args]]
+    # ``python -m dbt`` fails when a local ``dbt`` folder shadows the installed
+    # package. Invoke the CLI's main module instead to avoid this issue.
+    commands = [["dbt", *args], [sys.executable, "-m", "dbt.cli.main", *args]]
     last_error: Exception | None = None
     for cmd in commands:
         try:


### PR DESCRIPTION
## Summary
- fix `_run_dbt` to call dbt via `dbt.cli.main`

## Testing
- `python -m py_compile run_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_685de4dfe9348327b382dba4555050db