### PR TITLE
Configure Superset admin account

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ If no run configuration is supplied, the job falls back to the values defined in
 ## Data visualization with Superset
 
 Superset provides an intuitive interface for exploring your data. The service
-runs on <http://localhost:8080>. The container ships with a default
-administrator account. Log in using ``admin`` / ``admin`` and start exploring
-the warehouse. You can change the password or create additional users from
-Superset's **Settings → List Users** menu.
+ runs on <http://localhost:8080>. The container creates an initial administrator
+ account for you. Log in using ``max`` / ``admin`` and start exploring the
+ warehouse. You can change the password or create additional users from
+  Superset's **Settings → List Users** menu.
 
 CSV files and Superset assets are stored locally as part of the Docker volumes.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,11 @@ services:
       SUPERSET_SECRET_KEY: superset-secret
       SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@superset_db:5432/superset
       REDIS_HOST: superset_cache
+      ADMIN_USERNAME: max
+      ADMIN_FIRSTNAME: Max
+      ADMIN_LASTNAME: Account
+      ADMIN_EMAIL: max@example.com
+      ADMIN_PASSWORD: admin
     ports:
       - "8080:8088"
 


### PR DESCRIPTION
## Summary
- create Superset admin user via environment vars in docker-compose
- update README with new login credentials

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de95c4f3c832796b11ef93000c372