### PR TITLE
Add helper for external seed paths

### DIFF
--- a/sources/commodities.py
+++ b/sources/commodities.py
@@ -1,16 +1,10 @@
 from datetime import datetime, timedelta
-from pathlib import Path
+from utils import external_seed_path
 import pandas as pd
 import yfinance as yf
 
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "commodity_prices.csv"
-)
+DATA_PATH = external_seed_path("commodity_prices.csv")
 
 
 def fetch() -> None:

--- a/sources/exchange_rates.py
+++ b/sources/exchange_rates.py
@@ -1,16 +1,10 @@
 from datetime import datetime, timezone
-from pathlib import Path
+from utils import external_seed_path
 
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "exchange_rates.csv"
-)
+DATA_PATH = external_seed_path("exchange_rates.csv")
 
 
 def fetch() -> None:

--- a/sources/stocks.py
+++ b/sources/stocks.py
@@ -1,16 +1,10 @@
 from datetime import datetime, timedelta
-from pathlib import Path
+from utils import external_seed_path
 
 import pandas as pd
 import yfinance as yf
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "stock_prices.csv"
-)
+DATA_PATH = external_seed_path("stock_prices.csv")
 
 
 def fetch() -> None:

--- a/sources/weather.py
+++ b/sources/weather.py
@@ -1,15 +1,9 @@
 from datetime import datetime, timedelta
-from pathlib import Path
+from utils import external_seed_path
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "weather.csv"
-)
+DATA_PATH = external_seed_path("weather.csv")
 
 
 def fetch() -> None:

--- a/sources/weather_forecast.py
+++ b/sources/weather_forecast.py
@@ -1,14 +1,8 @@
-from pathlib import Path
+from utils import external_seed_path
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "weather_forecast.csv"
-)
+DATA_PATH = external_seed_path("weather_forecast.csv")
 
 
 def fetch() -> None:

--- a/sources/world_bank.py
+++ b/sources/world_bank.py
@@ -1,14 +1,8 @@
-from pathlib import Path
+from utils import external_seed_path
 import pandas as pd
 import requests
 
-DATA_PATH = (
-    Path(__file__).resolve().parent.parent
-    / "dbt"
-    / "seeds"
-    / "external"
-    / "world_bank_gdp.csv"
-)
+DATA_PATH = external_seed_path("world_bank_gdp.csv")
 
 
 def fetch() -> None:

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,11 @@ DBT_DIR = Path(__file__).parent / "dbt"
 CONFIG_FILE = Path(__file__).parent / "pipeline_config.yml"
 
 
+def external_seed_path(filename: str) -> Path:
+    """Return the path to an external seed file in the dbt directory."""
+    return DBT_DIR / "seeds" / "external" / filename
+
+
 def _run_dbt(args: list[str]) -> None:
     """Execute a dbt command with a fallback to ``python -m dbt.cli.main``."""
     commands = [["dbt", *args], [sys.executable, "-m", "dbt.cli.main", *args]]


### PR DESCRIPTION
## Summary
- create `external_seed_path` helper in utils
- switch data source modules to use helper for CSV locations

## Testing
- `python -m py_compile utils.py sources/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685de990d49483278d5eba5a74c840cd