### PR TITLE
Centralize fetcher invocation utility

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,18 +1,11 @@
 """Run a single pipeline execution without Dagster."""
 import argparse
-import importlib
-
-from utils import _run_dbt, load_config, active_models
+from utils import _run_dbt, load_config, active_models, invoke_fetcher
 
 
 
 def fetch(fetcher: str) -> None:
-    if "." not in fetcher:
-        raise ValueError(f"Invalid fetcher '{fetcher}'. Expected 'module.func'")
-    module_path, func_name = fetcher.rsplit(".", 1)
-    module = importlib.import_module(module_path)
-    func = getattr(module, func_name)
-    func()
+    invoke_fetcher(fetcher)
 
 
 def run_dbt(models: list[str] | None) -> None:

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 import sys
+import importlib
 import yaml
 
 DBT_DIR = Path(__file__).parent / "dbt"
@@ -45,3 +46,13 @@ def load_config() -> dict:
 
 def active_models(cfg: dict) -> set[str]:
     return {m.get("name") for m in cfg.get("models", []) if m.get("active")}
+
+
+def invoke_fetcher(path: str) -> None:
+    """Import and execute a fetcher given by dotted path."""
+    if "." not in path:
+        raise ValueError(f"Invalid fetcher '{path}'. Expected 'module.func'")
+    module_path, func_name = path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    func = getattr(module, func_name)
+    func()


### PR DESCRIPTION
## Summary
- add `invoke_fetcher` helper to manage dynamic imports
- refactor `run_pipeline` and `dagster_pipeline` to use new helper

## Testing
- `python -m py_compile utils.py run_pipeline.py dagster_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_685deb8b9bec8327821a57fb64e9df5e