### PR TITLE
Disable auth for Superset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       SUPERSET_SECRET_KEY: superset-secret
       SQLALCHEMY_DATABASE_URI: postgresql+psycopg2://superset:superset@superset_db:5432/superset
       REDIS_HOST: superset_cache
+      SUPERSET_CONFIG_PATH: /app/pythonpath/superset_config.py
       ADMIN_USERNAME: max
       ADMIN_FIRSTNAME: Max
       ADMIN_LASTNAME: Account
@@ -38,6 +39,8 @@ services:
       ADMIN_PASSWORD: admin
     ports:
       - "8080:8088"
+    volumes:
+      - ./superset_config.py:/app/pythonpath/superset_config.py
 
   docs:
     build: .

--- a/superset_config.py
+++ b/superset_config.py
@@ -1,0 +1,3 @@
+AUTH_TYPE = 1
+AUTH_ROLE_PUBLIC = 'Admin'
+PUBLIC_ROLE_LIKE = 'Admin'


### PR DESCRIPTION
## Summary
- add `superset_config.py` with auth disabled
- mount the config file and set `SUPERSET_CONFIG_PATH` in docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685deb4922208327bff32861e5a55410