### PR TITLE
Refactor dbt execution helper

### DIFF
--- a/dagster_pipeline.py
+++ b/dagster_pipeline.py
@@ -1,7 +1,7 @@
 import importlib
 import os
 from dagster import Definitions, ScheduleDefinition, job, op, Field, Noneable
-from utils import DBT_DIR, _run_dbt, load_config, active_models
+from utils import DBT_DIR, load_config, active_models, run_dbt_steps
 
 os.environ.setdefault("DBT_PROFILES_DIR", str(DBT_DIR))
 
@@ -39,13 +39,7 @@ def run_dbt_pipeline(context, _start: bool) -> None:
         cfg = load_config()
         models = list(active_models(cfg))
         context.log.info("Using active models from config: %s", models)
-    _run_dbt(["seed"])
-    if models:
-        _run_dbt(["run", "-s", *models])
-        _run_dbt(["test", "-s", *models])
-    else:
-        _run_dbt(["run"])
-        _run_dbt(["test"])
+    run_dbt_steps(models)
 
 
 @job

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,7 +2,7 @@
 import argparse
 import importlib
 
-from utils import _run_dbt, load_config, active_models
+from utils import load_config, active_models, run_dbt_steps
 
 
 
@@ -13,16 +13,6 @@ def fetch(fetcher: str) -> None:
     module = importlib.import_module(module_path)
     func = getattr(module, func_name)
     func()
-
-
-def run_dbt(models: list[str] | None) -> None:
-    _run_dbt(["seed"])
-    if models:
-        _run_dbt(["run", "-s", *models])
-        _run_dbt(["test", "-s", *models])
-    else:
-        _run_dbt(["run"])
-        _run_dbt(["test"])
 
 
 def main() -> None:
@@ -43,7 +33,7 @@ def main() -> None:
     models = args.models if args.models is not None else list(active_models(cfg))
 
     fetch(fetcher)
-    run_dbt(models)
+    run_dbt_steps(models)
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -45,3 +45,14 @@ def load_config() -> dict:
 
 def active_models(cfg: dict) -> set[str]:
     return {m.get("name") for m in cfg.get("models", []) if m.get("active")}
+
+
+def run_dbt_steps(models: list[str] | None) -> None:
+    """Execute the seed, run and test dbt steps."""
+    _run_dbt(["seed"])
+    if models:
+        _run_dbt(["run", "-s", *models])
+        _run_dbt(["test", "-s", *models])
+    else:
+        _run_dbt(["run"])
+        _run_dbt(["test"])


### PR DESCRIPTION
## Summary
- centralize dbt run/test logic with `run_dbt_steps`
- use new helper in CLI and Dagster pipeline

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685deba4f11083278fe0013f56f5566f