### PR TITLE
Fix dependency error for YAML parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dbt-duckdb = "*"
 pandas = "*"
 yfinance = "*"
 requests = "*"
+pyyaml = "*"
 
 [tool.poetry.group.dev.dependencies]
 # Add dev dependencies here

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ yfinance
 dagster
 dagster-webserver
 requests
+pyyaml


### PR DESCRIPTION
## Summary
- add missing dependency `pyyaml` to `requirements.txt`
- include `pyyaml` in `pyproject.toml`

## Testing
- `python run_pipeline.py` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_685def48b1e483279c76e58688638bf4