### PR TITLE
Add automatic Superset admin creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,12 @@ If no run configuration is supplied, the job falls back to the values defined in
 ## Data visualization with Superset
 
 Superset provides an intuitive interface for exploring your data. The service
- runs on <http://localhost:8080>. The container creates an initial administrator
- account for you. Log in using ``max`` / ``admin`` and start exploring the
- warehouse. You can change the password or create additional users from
-  Superset's **Settings → List Users** menu.
+runs on <http://localhost:8080>. The compose file bootstraps an administrator
+account by executing ``superset fab create-admin`` when the container starts.
+By default the credentials are ``max`` / ``admin``. You can change them through
+the environment variables defined in ``docker-compose.yml``. After logging in
+you may change the password or add more users from Superset's
+**Settings → List Users** menu.
 
 CSV files and Superset assets are stored locally as part of the Docker volumes.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,17 @@ services:
       ADMIN_LASTNAME: Account
       ADMIN_EMAIL: max@example.com
       ADMIN_PASSWORD: admin
+    command: >-
+      /bin/bash -c "\
+      superset db upgrade && \
+      superset fab create-admin \
+        --username $ADMIN_USERNAME \
+        --firstname $ADMIN_FIRSTNAME \
+        --lastname $ADMIN_LASTNAME \
+        --email $ADMIN_EMAIL \
+        --password $ADMIN_PASSWORD && \
+      superset init && \
+      superset run -h 0.0.0.0 -p 8088"
     ports:
       - "8080:8088"
     volumes:


### PR DESCRIPTION
## Summary
- run `superset fab create-admin` during container startup
- document admin bootstrap process

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685deffca8548327a564ae749ddd3b0f