### PR TITLE
Fix superset create-admin command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,17 +37,18 @@ services:
       ADMIN_LASTNAME: Account
       ADMIN_EMAIL: max@example.com
       ADMIN_PASSWORD: admin
-    command: >-
-      /bin/bash -c "\
-      superset db upgrade && \
+    command: |
+      /bin/bash -c "
+      superset db upgrade &&
       superset fab create-admin \
         --username $ADMIN_USERNAME \
         --firstname $ADMIN_FIRSTNAME \
         --lastname $ADMIN_LASTNAME \
         --email $ADMIN_EMAIL \
-        --password $ADMIN_PASSWORD && \
-      superset init && \
-      superset run -h 0.0.0.0 -p 8088"
+        --password $ADMIN_PASSWORD &&
+      superset init &&
+      superset run -h 0.0.0.0 -p 8088
+      "
     ports:
       - "8080:8088"
     volumes:


### PR DESCRIPTION
## Summary
- update compose command to avoid backslash mishandling when bootstrapping Superset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df278372c8327a2579f7bb3e74ff3