### PR TITLE
Simplify schedule handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ The typical workflow when extending the warehouse is:
 
 3. **Automate the pipeline**
    - Register active models using `register_model.py` and edit
-     `pipeline_config.yml` to add the fetcher, desired models and schedule.
+     `pipeline_config.yml` to add the fetcher, desired models and a cron
+     schedule (e.g. `"0 0 * * *"`).
 
      ```bash
      poetry run python register_model.py your_model --activate

--- a/dagster_pipeline.py
+++ b/dagster_pipeline.py
@@ -52,29 +52,7 @@ def pipeline_job() -> None:
     """Dagster job that fetches data and executes dbt."""
     run_dbt_pipeline(fetch_data())
 
-
-
-
-def parse_cron(expr: str) -> str:
-    s = str(expr).lower()
-    if s == "hourly":
-        return "0 * * * *"
-    if s == "daily":
-        return "0 0 * * *"
-    if s == "weekly":
-        return "0 0 * * 0"
-    if s.startswith("every"):
-        parts = s.split()
-        if len(parts) >= 3:
-            interval = int(parts[1])
-            unit = parts[2].rstrip("s")
-            if unit == "hour":
-                return f"0 */{interval} * * *"
-            if unit == "day":
-                return f"0 0 */{interval} * *"
-        raise ValueError(f"Invalid schedule format: {expr}")
-    hour, minute = map(int, s.split(":"))
-    return f"{minute} {hour} * * *"
+DEFAULT_CRON = "0 0 * * *"
 
 
 def create_schedules():
@@ -84,7 +62,7 @@ def create_schedules():
     for source in cfg.get("sources", []):
         fetcher = source["fetcher"]
         models = [m for m in source.get("models", []) if m in active]
-        cron = parse_cron(source.get("schedule", "hourly"))
+        cron = source.get("schedule", DEFAULT_CRON)
         schedules.append(
             ScheduleDefinition(
                 job=pipeline_job,

--- a/pipeline_config.yml
+++ b/pipeline_config.yml
@@ -7,7 +7,7 @@ models:
 sources:
   - name: basketball_stats
     fetcher: sources.basketball.fetch
-    schedule: "daily"
+    schedule: "0 0 * * *"
     models:
       - player_stats
       - player_efficiency


### PR DESCRIPTION
## Summary
- expect cron expressions in `pipeline_config.yml`
- remove cron parsing logic and use a daily default
- document cron schedule requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dfb29e99c83278c7d0ff1ea5e4d2d