### PR TITLE
Expand basketball dataset and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ stored locally under `dbt/seeds/external`. Open the database in
 [DBeaver](https://dbeaver.io/) to explore tables created by dbt. Models are
 grouped into `bronze`, `silver` and `gold` schemas rather than having the stage
 as part of the table name. Several sample
-The example pipeline now focuses on basketball statistics. A single fetcher
-downloads NBA season averages from the free `balldontlie` API and stores them
-as CSV files. dbt models calculate per player metrics such as an efficiency
-score derived from those season averages.
+The example pipeline now focuses on basketball statistics. The fetcher
+downloads player, team and game data from the free `balldontlie` API and stores
+them as CSV files. dbt models build a star schema with player and team
+dimensions plus game level facts. Additional models calculate metrics like
+player efficiency for richer analysis.
 
 ## Development workflow
 

--- a/dagster_pipeline.py
+++ b/dagster_pipeline.py
@@ -3,7 +3,15 @@ from dagster import Definitions, ScheduleDefinition, job, op, Field, Noneable
 from utils import DBT_DIR, _run_dbt, invoke_fetcher
 
 DEFAULT_FETCHER = "sources.basketball.fetch"
-DEFAULT_MODELS = ["player_stats", "player_efficiency"]
+DEFAULT_MODELS = [
+    "player_stats",
+    "players",
+    "teams",
+    "games",
+    "game_stats",
+    "player_efficiency",
+    "player_game_facts",
+]
 DEFAULT_CRON = "0 0 * * *"
 
 

--- a/dbt/models/bronze/stg_game_stats.sql
+++ b/dbt/models/bronze/stg_game_stats.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('game_stats') }}

--- a/dbt/models/bronze/stg_games.sql
+++ b/dbt/models/bronze/stg_games.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('games') }}

--- a/dbt/models/bronze/stg_players.sql
+++ b/dbt/models/bronze/stg_players.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('players') }}

--- a/dbt/models/bronze/stg_teams.sql
+++ b/dbt/models/bronze/stg_teams.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('teams') }}

--- a/dbt/models/gold/player_game_facts.sql
+++ b/dbt/models/gold/player_game_facts.sql
@@ -1,0 +1,33 @@
+with stats as (
+    select * from {{ ref('game_stats') }}
+),
+players as (
+    select * from {{ ref('players') }}
+),
+teams as (
+    select * from {{ ref('teams') }}
+),
+games as (
+    select * from {{ ref('games') }}
+)
+select
+    stats.game_id,
+    games.date,
+    games.season,
+    stats.player_id,
+    players.first_name,
+    players.last_name,
+    players.position,
+    stats.team_id,
+    teams.full_name as team_name,
+    games.home_team_id,
+    games.visitor_team_id,
+    games.home_team_score,
+    games.visitor_team_score,
+    stats.pts,
+    stats.reb,
+    stats.ast
+from stats
+left join players on stats.player_id = players.player_id
+left join teams on stats.team_id = teams.team_id
+left join games on stats.game_id = games.game_id

--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -10,3 +10,21 @@ models:
       - name: efficiency
         tests:
           - not_null
+  - name: stg_players
+    description: Raw player information from the balldontlie API.
+  - name: stg_teams
+    description: Raw team information from the balldontlie API.
+  - name: stg_games
+    description: Raw game information from the balldontlie API.
+  - name: stg_game_stats
+    description: Player game statistics from the balldontlie API.
+  - name: players
+    description: Cleaned player dimension.
+  - name: teams
+    description: Cleaned team dimension.
+  - name: games
+    description: Cleaned games dimension.
+  - name: game_stats
+    description: Fact table with basic player statistics per game.
+  - name: player_game_facts
+    description: Denormalized view joining players, teams and games.

--- a/dbt/models/silver/game_stats.sql
+++ b/dbt/models/silver/game_stats.sql
@@ -1,0 +1,8 @@
+select
+    game_id,
+    player_id,
+    team_id,
+    pts,
+    reb,
+    ast
+from {{ ref('stg_game_stats') }}

--- a/dbt/models/silver/games.sql
+++ b/dbt/models/silver/games.sql
@@ -1,0 +1,10 @@
+select
+    id as game_id,
+    date,
+    season,
+    home_team_id,
+    visitor_team_id,
+    home_team_score,
+    visitor_team_score,
+    postseason
+from {{ ref('stg_games') }}

--- a/dbt/models/silver/players.sql
+++ b/dbt/models/silver/players.sql
@@ -1,0 +1,7 @@
+select
+    id as player_id,
+    first_name,
+    last_name,
+    position,
+    team_id
+from {{ ref('stg_players') }}

--- a/dbt/models/silver/teams.sql
+++ b/dbt/models/silver/teams.sql
@@ -1,0 +1,8 @@
+select
+    id as team_id,
+    full_name,
+    abbreviation,
+    city,
+    conference,
+    division
+from {{ ref('stg_teams') }}

--- a/dbt/seeds/external/game_stats.csv
+++ b/dbt/seeds/external/game_stats.csv
@@ -1,0 +1,3 @@
+id,game_id,player_id,team_id,pts,reb,ast
+1,47187,237,14,28,10,8
+2,47187,115,17,33,6,5

--- a/dbt/seeds/external/games.csv
+++ b/dbt/seeds/external/games.csv
@@ -1,0 +1,2 @@
+id,date,season,home_team_id,visitor_team_id,home_team_score,visitor_team_score,postseason
+47187,2023-04-15,2022,14,17,105,90,false

--- a/dbt/seeds/external/players.csv
+++ b/dbt/seeds/external/players.csv
@@ -1,0 +1,3 @@
+id,first_name,last_name,position,team_id
+237,LeBron,James,F,14
+115,Kevin,Durant,F,17

--- a/dbt/seeds/external/teams.csv
+++ b/dbt/seeds/external/teams.csv
@@ -1,0 +1,3 @@
+id,abbreviation,city,conference,division,full_name,name
+14,LAL,Los Angeles,West,Pacific,Los Angeles Lakers,Lakers
+17,BKN,Brooklyn,East,Atlantic,Brooklyn Nets,Nets

--- a/sources/basketball.py
+++ b/sources/basketball.py
@@ -1,35 +1,106 @@
+from __future__ import annotations
+
 import pandas as pd
 import requests
+from pathlib import Path
 from utils import external_seed_path
 
-DATA_PATH = external_seed_path("season_averages.csv")
+SEASON_AVERAGES_PATH = external_seed_path("season_averages.csv")
+PLAYERS_PATH = external_seed_path("players.csv")
+TEAMS_PATH = external_seed_path("teams.csv")
+GAMES_PATH = external_seed_path("games.csv")
+GAME_STATS_PATH = external_seed_path("game_stats.csv")
 
-API_URL = "https://www.balldontlie.io/api/v1/season_averages"
+API_BASE = "https://www.balldontlie.io/api/v1"
 
 
-def fetch(season: int = 2022, max_player_id: int = 100, batch_size: int = 25) -> None:
-    """Download NBA season averages using the balldontlie API."""
+def _save_csv(path: Path, records: list[dict]) -> None:
+    """Save records to ``path`` as CSV."""
+    if not records:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame.from_records(records).to_csv(path, index=False)
 
+
+def fetch_season_averages(season: int, max_player_id: int) -> None:
+    """Fetch season averages for a range of players."""
     params = {
         "season": season,
         "player_ids[]": list(range(1, max_player_id + 1)),
     }
     try:
-        resp = requests.get(API_URL, params=params, timeout=30)
+        resp = requests.get(f"{API_BASE}/season_averages", params=params, timeout=30)
         resp.raise_for_status()
     except Exception:
         return
     data = resp.json().get("data", [])
-    records = []
-    for record in data:
-        record["season"] = season
-        records.append(record)
+    for rec in data:
+        rec["season"] = season
+    _save_csv(SEASON_AVERAGES_PATH, data)
 
-    if not records:
+
+def _paginate(url: str, params: dict[str, int | str] | None = None, max_pages: int | None = None) -> list[dict]:
+    records: list[dict] = []
+    page = 1
+    while True:
+        page_params = {"page": page, "per_page": 100}
+        if params:
+            page_params.update(params)
+        try:
+            resp = requests.get(url, params=page_params, timeout=30)
+            resp.raise_for_status()
+        except Exception:
+            break
+        payload = resp.json()
+        records.extend(payload.get("data", []))
+        meta = payload.get("meta", {})
+        if not meta.get("next_page"):
+            break
+        page += 1
+        if max_pages and page > max_pages:
+            break
+    return records
+
+
+def fetch_players(max_pages: int | None = None) -> None:
+    records = _paginate(f"{API_BASE}/players", max_pages=max_pages)
+    _save_csv(PLAYERS_PATH, records)
+
+
+def fetch_teams() -> None:
+    try:
+        resp = requests.get(f"{API_BASE}/teams", timeout=30)
+        resp.raise_for_status()
+    except Exception:
         return
-    DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
-    df = pd.DataFrame.from_records(records)
-    df.to_csv(DATA_PATH, index=False)
+    _save_csv(TEAMS_PATH, resp.json().get("data", []))
+
+
+def fetch_games(season: int, max_pages: int | None = None) -> None:
+    records = _paginate(
+        f"{API_BASE}/games",
+        params={"seasons[]": season},
+        max_pages=max_pages,
+    )
+    _save_csv(GAMES_PATH, records)
+
+
+def fetch_game_stats(season: int, max_pages: int | None = None) -> None:
+    records = _paginate(
+        f"{API_BASE}/stats",
+        params={"seasons[]": season},
+        max_pages=max_pages,
+    )
+    _save_csv(GAME_STATS_PATH, records)
+
+
+def fetch(season: int = 2022, max_player_id: int = 100, pages: int | None = 1) -> None:
+    """Download basketball data from the balldontlie API."""
+    fetch_season_averages(season, max_player_id)
+    fetch_players(max_pages=pages)
+    fetch_teams()
+    fetch_games(season, max_pages=pages)
+    fetch_game_stats(season, max_pages=pages)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- pull more NBA data using new fetcher
- add players, teams, games and game stats seed files
- build bronze/silver models for new tables
- create `player_game_facts` gold model
- include new models in Dagster defaults
- adjust tests and docs for the expanded dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e07ade5e083279196a8472fcd4428