### PR TITLE
Add financial data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ stored locally under `dbt/seeds/external`. Open the database in
 [DBeaver](https://dbeaver.io/) to explore tables created by dbt. Models are
 grouped into `bronze`, `silver` and `gold` schemas rather than having the stage
 as part of the table name. Several sample
-The example pipeline now focuses on basketball statistics. The fetcher
-downloads player, team and game data from the free `balldontlie` API and stores
-them as CSV files. dbt models build a star schema with player and team
-dimensions plus game level facts. Additional models calculate metrics like
-player efficiency for richer analysis.
+The example pipeline now focuses on financial market data. The fetcher
+downloads stock and commodity prices for a list of tickers using Yahoo! Finance,
+weather history from Meteostat and impactful news headlines via the NewsAPI. All
+data is stored as CSV files which dbt transforms into daily fact tables. These
+models can then be joined to analyze how markets react to external events such
+as weather changes or major news stories.
 
 ## Development workflow
 
@@ -70,7 +71,7 @@ The typical workflow when extending the warehouse is:
      variables. For example:
 
      ```bash
-     export FETCHER=sources.basketball.fetch
+    export FETCHER=sources.finance.fetch
      export MODELS=player_stats,player_efficiency
      export SCHEDULE=daily
      ```
@@ -104,7 +105,7 @@ Provide a run configuration that specifies the fetcher and the dbt models to exe
 ops:
   fetch_data:
     config:
-      fetcher: sources.basketball.fetch
+      fetcher: sources.finance.fetch
   run_dbt_pipeline:
     config:
       models: [player_efficiency]
@@ -120,7 +121,7 @@ through environment variables.
 - `sources/` – Python modules for fetching raw data.
 - `dbt/` – dbt project containing models and configuration.
   - Raw CSV files are stored under `dbt/seeds/external`.
-  - `sources/basketball.py` downloads NBA season averages.
+  - `sources/finance.py` downloads market data and news.
 
 ## Data visualization with Jupyter
 

--- a/dagster_pipeline.py
+++ b/dagster_pipeline.py
@@ -2,7 +2,7 @@ import os
 from dagster import Definitions, ScheduleDefinition, job, op, Field, Noneable
 from utils import DBT_DIR, _run_dbt, invoke_fetcher
 
-DEFAULT_FETCHER = "sources.basketball.fetch"
+DEFAULT_FETCHER = "sources.finance.fetch"
 DEFAULT_MODELS = [
     "player_stats",
     "players",

--- a/dbt/models/bronze/stg_commodity_prices.sql
+++ b/dbt/models/bronze/stg_commodity_prices.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('commodity_prices') }}

--- a/dbt/models/bronze/stg_news.sql
+++ b/dbt/models/bronze/stg_news.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('news') }}

--- a/dbt/models/bronze/stg_stock_prices.sql
+++ b/dbt/models/bronze/stg_stock_prices.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('stock_prices') }}

--- a/dbt/models/bronze/stg_weather.sql
+++ b/dbt/models/bronze/stg_weather.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('weather') }}

--- a/dbt/models/gold/daily_market_data.sql
+++ b/dbt/models/gold/daily_market_data.sql
@@ -1,0 +1,24 @@
+with stocks as (
+    select * from {{ ref('stock_prices') }}
+),
+commodities as (
+    select * from {{ ref('commodity_prices') }}
+),
+weather as (
+    select * from {{ ref('weather') }}
+),
+news as (
+    select * from {{ ref('news') }}
+)
+select
+    s.date,
+    s.ticker as stock_ticker,
+    s.adj_close as stock_close,
+    c.ticker as commodity_ticker,
+    c.adj_close as commodity_close,
+    w.tavg,
+    n.title as headline
+from stocks s
+left join commodities c on s.date = c.date
+left join weather w on s.date = w.date
+left join news n on s.date = n.date

--- a/dbt/models/schema.yml
+++ b/dbt/models/schema.yml
@@ -28,3 +28,21 @@ models:
     description: Fact table with basic player statistics per game.
   - name: player_game_facts
     description: Denormalized view joining players, teams and games.
+  - name: stg_stock_prices
+    description: Raw historical stock prices fetched from Yahoo! Finance.
+  - name: stg_commodity_prices
+    description: Raw commodity prices from Yahoo! Finance.
+  - name: stg_weather
+    description: Daily weather measurements.
+  - name: stg_news
+    description: News headlines with publication dates.
+  - name: stock_prices
+    description: Cleaned daily closing prices for stocks.
+  - name: commodity_prices
+    description: Cleaned daily commodity prices.
+  - name: weather
+    description: Cleaned weather data.
+  - name: news
+    description: News articles by date.
+  - name: daily_market_data
+    description: Combined view of prices, weather and news by date.

--- a/dbt/models/silver/commodity_prices.sql
+++ b/dbt/models/silver/commodity_prices.sql
@@ -1,0 +1,5 @@
+select
+    cast(date as date) as date,
+    ticker,
+    "Adj Close" as adj_close
+from {{ ref('stg_commodity_prices') }}

--- a/dbt/models/silver/news.sql
+++ b/dbt/models/silver/news.sql
@@ -1,0 +1,5 @@
+select
+    cast(date as date) as date,
+    title,
+    url
+from {{ ref('stg_news') }}

--- a/dbt/models/silver/stock_prices.sql
+++ b/dbt/models/silver/stock_prices.sql
@@ -1,0 +1,5 @@
+select
+    cast(date as date) as date,
+    ticker,
+    "Adj Close" as adj_close
+from {{ ref('stg_stock_prices') }}

--- a/dbt/models/silver/weather.sql
+++ b/dbt/models/silver/weather.sql
@@ -1,0 +1,4 @@
+select
+    cast(time as date) as date,
+    tavg
+from {{ ref('stg_weather') }}

--- a/dbt/seeds/external/commodity_prices.csv
+++ b/dbt/seeds/external/commodity_prices.csv
@@ -1,0 +1,2 @@
+date,ticker,Open,High,Low,Close,Adj Close,Volume
+2023-01-02,GC=F,1800,1850,1790,1830,1830,0

--- a/dbt/seeds/external/news.csv
+++ b/dbt/seeds/external/news.csv
@@ -1,0 +1,2 @@
+date,title,url
+2023-01-02,Example headline,http://example.com/news1

--- a/dbt/seeds/external/stock_prices.csv
+++ b/dbt/seeds/external/stock_prices.csv
@@ -1,0 +1,2 @@
+date,ticker,Open,High,Low,Close,Adj Close,Volume
+2023-01-02,AAPL,130,135,129,133,133,1000000

--- a/dbt/seeds/external/weather.csv
+++ b/dbt/seeds/external/weather.csv
@@ -1,0 +1,2 @@
+time,tavg,tmin,tmax,prcp,snow,wdir,wspd,wpgt,pres
+2023-01-02,5,3,7,0,0,180,10,15,1015

--- a/fetch_seeds.py
+++ b/fetch_seeds.py
@@ -1,4 +1,4 @@
-from sources.basketball import fetch
+from sources.finance import fetch
 
 if __name__ == "__main__":
     fetch()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ pandas = "*"
 pyyaml = "*"
 jupyter = "*"
 plotly = "*"
+yfinance = "*"
+meteostat = "*"
+newsapi-python = "*"
 
 [tool.poetry.group.dev.dependencies]
 # Add dev dependencies here

--- a/sources/finance.py
+++ b/sources/finance.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+import os
+
+import pandas as pd
+
+try:
+    import yfinance as yf
+except Exception:  # pragma: no cover - optional dependency
+    yf = None
+
+try:
+    from meteostat import Daily, Point
+except Exception:  # pragma: no cover - optional dependency
+    Daily = None
+    Point = None
+
+try:
+    from newsapi import NewsApiClient
+except Exception:  # pragma: no cover - optional dependency
+    NewsApiClient = None
+
+from utils import external_seed_path
+
+STOCK_PRICES_PATH = external_seed_path("stock_prices.csv")
+COMMODITY_PRICES_PATH = external_seed_path("commodity_prices.csv")
+WEATHER_PATH = external_seed_path("weather.csv")
+NEWS_PATH = external_seed_path("news.csv")
+
+
+START_DATE = date.today() - timedelta(days=5 * 365)
+END_DATE = date.today()
+
+
+# Example lists - adjust as needed
+STOCK_TICKERS = [
+    "AAPL", "MSFT", "GOOGL", "AMZN", "META", "TSLA", "NVDA", "JPM",
+    "JNJ", "V", "PG", "UNH", "HD", "MA", "BAC", "PFE", "DIS", "INTC",
+    "VZ", "KO",
+]
+
+COMMODITY_TICKERS = [
+    "GC=F",  # Gold
+    "CL=F",  # Crude Oil
+    "SI=F",  # Silver
+]
+
+
+API_KEY_ENV = "NEWSAPI_KEY"
+
+
+def _save_csv(path: Path, df: pd.DataFrame) -> None:
+    if df.empty:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def fetch_stock_prices(tickers: list[str] | None = None) -> None:
+    if yf is None:
+        return
+    if tickers is None:
+        tickers = STOCK_TICKERS
+    data = yf.download(
+        tickers=tickers,
+        start=START_DATE.strftime("%Y-%m-%d"),
+        end=END_DATE.strftime("%Y-%m-%d"),
+        group_by="ticker",
+        threads=True,
+    )
+    records: list[pd.DataFrame] = []
+    if isinstance(data, pd.DataFrame) and "Adj Close" in data.columns:
+        data = {"PRICE": data}
+    for ticker in tickers:
+        if ticker in data:
+            df = data[ticker].copy()
+            df.reset_index(inplace=True)
+            df.insert(0, "ticker", ticker)
+            records.append(df)
+    if records:
+        df_out = pd.concat(records)
+        _save_csv(STOCK_PRICES_PATH, df_out)
+
+
+def fetch_commodity_prices(tickers: list[str] | None = None) -> None:
+    if yf is None:
+        return
+    if tickers is None:
+        tickers = COMMODITY_TICKERS
+    data = yf.download(
+        tickers=tickers,
+        start=START_DATE.strftime("%Y-%m-%d"),
+        end=END_DATE.strftime("%Y-%m-%d"),
+        group_by="ticker",
+        threads=True,
+    )
+    records: list[pd.DataFrame] = []
+    for ticker in tickers:
+        if ticker in data:
+            df = data[ticker].copy()
+            df.reset_index(inplace=True)
+            df.insert(0, "ticker", ticker)
+            records.append(df)
+    if records:
+        df_out = pd.concat(records)
+        _save_csv(COMMODITY_PRICES_PATH, df_out)
+
+
+def fetch_weather(lat: float = 40.7128, lon: float = -74.0060) -> None:
+    if Daily is None or Point is None:
+        return
+    location = Point(lat, lon)
+    data = Daily(location, START_DATE, END_DATE)
+    df = data.fetch().reset_index()
+    _save_csv(WEATHER_PATH, df)
+
+
+def fetch_news() -> None:
+    if NewsApiClient is None:
+        return
+    api_key = os.getenv(API_KEY_ENV)
+    if not api_key:
+        return
+    client = NewsApiClient(api_key=api_key)
+    all_articles = []
+    from_date = START_DATE
+    while from_date < END_DATE:
+        to_date = from_date + timedelta(days=30)
+        resp = client.get_everything(
+            q="stock market",
+            from_param=from_date.strftime("%Y-%m-%d"),
+            to=to_date.strftime("%Y-%m-%d"),
+            language="en",
+            sort_by="relevancy",
+            page_size=100,
+        )
+        articles = resp.get("articles", [])
+        for art in articles:
+            art["date"] = art.get("publishedAt", "")[:10]
+        all_articles.extend(articles)
+        from_date = to_date
+    if all_articles:
+        df = pd.DataFrame(all_articles)
+        _save_csv(NEWS_PATH, df)
+
+
+def fetch() -> None:
+    """Fetch financial data, weather and news."""
+    fetch_stock_prices()
+    fetch_commodity_prices()
+    fetch_weather()
+    fetch_news()
+
+
+if __name__ == "__main__":
+    fetch()


### PR DESCRIPTION
## Summary
- add new finance data fetcher for stocks, commodities, weather and news
- fetch seeds using new finance fetcher
- update pipeline default fetcher
- include sample seeds and dbt models for market data
- document new workflow and dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e509e8de0832794d3bafdc6e34661