### PR TITLE
Add Alpaca connection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,13 @@ suite using `pytest`:
 poetry install --with dev
 poetry run pytest -q
 ```
+
+## Connecting to Alpaca
+
+Trading bots can access the Alpaca API using the helper in `bots/alpaca.py`. Set the following environment variables so the client can authenticate:
+
+- `ALPACA_API_KEY` – your Alpaca API key
+- `ALPACA_SECRET_KEY` – your Alpaca secret
+- `ALPACA_BASE_URL` – optional base URL, defaults to `https://paper-api.alpaca.markets`
+
+Create a session by calling `bots.alpaca.get_session()` which returns a configured `requests.Session` ready to make authenticated requests.

--- a/bots/alpaca.py
+++ b/bots/alpaca.py
@@ -1,0 +1,24 @@
+import os
+import requests
+
+ALPACA_KEY_ENV = "ALPACA_API_KEY"
+ALPACA_SECRET_ENV = "ALPACA_SECRET_KEY"
+ALPACA_URL_ENV = "ALPACA_BASE_URL"
+DEFAULT_BASE_URL = "https://paper-api.alpaca.markets"
+
+
+def get_session(api_key: str | None = None, secret_key: str | None = None,
+                base_url: str | None = None) -> requests.Session:
+    """Return a configured ``requests.Session`` for the Alpaca API."""
+    api_key = api_key or os.getenv(ALPACA_KEY_ENV)
+    secret_key = secret_key or os.getenv(ALPACA_SECRET_ENV)
+    base_url = base_url or os.getenv(ALPACA_URL_ENV, DEFAULT_BASE_URL)
+    if not api_key or not secret_key:
+        raise ValueError("Missing Alpaca API credentials")
+    session = requests.Session()
+    session.headers.update({
+        "APCA-API-KEY-ID": api_key,
+        "APCA-API-SECRET-KEY": secret_key,
+    })
+    session.base_url = base_url  # type: ignore[attr-defined]
+    return session

--- a/tests/test_alpaca.py
+++ b/tests/test_alpaca.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+import importlib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_get_session_uses_env(monkeypatch):
+    calls = {}
+
+    class DummySession:
+        def __init__(self):
+            calls['created'] = True
+            self.headers = {}
+
+    dummy_requests = ModuleType('requests')
+    dummy_requests.Session = DummySession
+
+    with monkeypatch.context() as m:
+        m.setitem(sys.modules, 'requests', dummy_requests)
+        m.setenv('ALPACA_API_KEY', 'key')
+        m.setenv('ALPACA_SECRET_KEY', 'secret')
+        alpaca = importlib.import_module('bots.alpaca')
+        sess = alpaca.get_session()
+
+    assert calls.get('created')
+    assert sess.headers['APCA-API-KEY-ID'] == 'key'
+    assert sess.headers['APCA-API-SECRET-KEY'] == 'secret'
+    assert hasattr(sess, 'base_url')


### PR DESCRIPTION
## Summary
- add a simple Alpaca connection utility in `bots/alpaca.py`
- document the environment variables required to use Alpaca
- add a unit test for the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e58c3557883279b08f36742a65000